### PR TITLE
Fix compilation error due to type mismatch

### DIFF
--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -6,7 +6,7 @@
 
 import * as nodes from '../parser/cssNodes';
 import {TextDocument, Range, Position, Location, DocumentHighlightKind, DocumentHighlight,
-	SymbolInformation, SymbolKind, WorkspaceEdit, TextEdit} from 'vscode-languageserver-types';
+	SymbolInformation, SymbolKind, WorkspaceEdit, TextEdit, VersionedTextDocumentIdentifier} from 'vscode-languageserver-types';
 import {Symbols} from '../parser/cssSymbolScope';
 import {isColorValue} from '../services/languageFacts';
 
@@ -145,9 +145,12 @@ export class CSSNavigation {
 		let highlights = this.findDocumentHighlights(document, position, stylesheet);
 		let edits = highlights.map(h => TextEdit.replace(h.range, newName));
 		return {
-			changes: {
-				[document.uri]: edits
-			}
+			changes: [
+				{
+					textDocument: {uri: document.uri, version: document.version} as VersionedTextDocumentIdentifier,
+					edits
+				}
+			]
 		};
 	}
 


### PR DESCRIPTION
 Changes to be committed:
	modified:   src/services/cssNavigation.ts

The switch to vscode-languageserver-types v3.0.1-alpha.2 results in the following error:

```
src/services/cssNavigation.ts(147,10): error TS2322: Type '{ changes: { [x: string]: TextEdit[]; }; }' is not assignable to type 'WorkspaceEdit'.
  Types of property 'changes' are incompatible.
    Type '{ [x: string]: TextEdit[]; }' is not assignable to type 'TextDocumentEdit[]'.
      Property 'length' is missing in type '{ [x: string]: TextEdit[]; }'.
```

This commit fixes the above.