### PR TITLE
text-decoration-color update

### DIFF
--- a/src/data/browsers.js
+++ b/src/data/browsers.js
@@ -8458,6 +8458,12 @@
 				]
 			},
 			{
+				"name": "text-decoration-color",
+				"desc": "Specifies the color of text decoration (underlines overlines, and line-throughs) set on the element with text-decoration-line.",
+				"browsers": "FF36,C57,O44",
+				"restriction": "color"
+			},
+			{
 				"name": "text-decoration-line",
 				"desc": "Specifies what line decorations, if any, are added to the element.",
 				"browsers": "FF36",


### PR DESCRIPTION
Safari 7.1 supports it with `-webkit`.

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color