### PR TITLE
grid-row-start property browser support info

### DIFF
--- a/build/css-schema.xml
+++ b/build/css-schema.xml
@@ -3280,7 +3280,7 @@
 		<entry name="grid-row-gap" restriction="length" version="3.0" browsers="FF52,C57,S10.1,O44" ref="http://www.w3.org/TR/css-grid-1/#propdef-grid-row-gap" syntax="#item1 { $(name): 2em; }">
 			<desc>Specifies the gutters between grid rows.</desc>
 		</entry>
-		<entry name="grid-row-start" restriction="identifier, integer, enum" version="3.0" browsers="none" ref="http://www.w3.org/TR/css-grid-1/#propdef-grid-row-start" syntax="#item1 { $(name): span 2; }">
+		<entry name="grid-row-start" restriction="identifier, integer, enum" version="3.0" browsers="FF52,C57,S10.1,O44" ref="http://www.w3.org/TR/css-grid-1/#propdef-grid-row-start" syntax="#item1 { $(name): span 2; }">
 			<desc>Determine a grid item’s size and location within the grid by contributing a line, a span, or nothing (automatic) to its grid placement.</desc>
 			<values>
 				<value name="auto" version="3.0" browsers="all">

--- a/src/data/browsers.js
+++ b/src/data/browsers.js
@@ -3810,6 +3810,21 @@
 				"restriction": "length"
 			},
 			{
+				"name": "grid-row-start",
+				"desc": "Determine a grid item’s size and location within the grid by contributing a line, a span, or nothing (automatic) to its grid placement.",
+				"browsers": "FF52,C57,S10.1,O44",
+				"restriction": "identifier, integer, enum",
+				"values": [
+					{
+						"name": "auto",
+						"desc": "The property contributes nothing to the grid item’s placement, indicating auto-placement, an automatic span, or a default span of one."
+					},
+					{
+						"name": "span"
+					}
+				]
+			},
+			{
 				"name": "grid-template",
 				"desc": "Shorthand for setting grid-template-columns, grid-template-rows, and grid-template-areas in a single declaration.",
 				"browsers": "FF52,C57,S10.1,O44",


### PR DESCRIPTION
CC : https://github.com/Microsoft/vscode/issues/27590 

- One thing I noticed is that even though css-schema.xml has the description for the span value, in built browsers.js it's not showing up. @aeschli - please help with this.