### PR TITLE
add system font stack in font-family autocomplete list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib/
 node_modules/
 coverage/
+npm-debug.log

--- a/build/css-schema.xml
+++ b/build/css-schema.xml
@@ -2438,6 +2438,7 @@
 		<entry name="font-family" restriction="font" version="1.0" browsers="all" ref="http://www.w3.org/TR/css3-fonts/#font-family0" syntax="body { $(name): arial, verdana; }">
 			<desc>Specifies a prioritized list of font family names or generic family names. A user agent iterates through the list of family names until it matches an available font that contains a glyph for the character to be rendered.</desc>
 			<values>
+				<value name="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif" version="1.0" browsers="all" />
 				<value name="Arial, Helvetica, sans-serif" version="1.0" browsers="all" />
 				<value name="Cambria, Cochin, Georgia, Times, Times New Roman, serif" version="1.0" browsers="all" />
 				<value name="Courier New, Courier, monospace" version="1.0" browsers="all" />

--- a/src/data/browsers.js
+++ b/src/data/browsers.js
@@ -2759,6 +2759,9 @@
 				"restriction": "font",
 				"values": [
 					{
+						"name": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif"
+					},
+					{
 						"name": "Arial, Helvetica, sans-serif"
 					},
 					{


### PR DESCRIPTION
- add: npm-debug.log to .gitignore

P.S - Do I need to create an issue for this?

## Why System Font Stack?
When working on electron projects and web apps, it's often desired for them to have the system native font so they can blend in the environment they are being operated.

Links
- https://css-tricks.com/snippets/css/system-font-stack/
- https://medium.com/@praveenpuglia/tiny-css-for-nativity-f9a4b7f0148c

## Could we use a different variant of the stack? 
May be. May be not. We can discuss this.