### PR TITLE
CSS Colors Level 4 - 4 & 8 digit hex values

### DIFF
--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -1217,7 +1217,7 @@ export class Parser {
 	}
 
 	public _parseHexColor(): nodes.Node {
-		if (this.peekRegExp(TokenType.Hash, /^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/g)) {
+		if (this.peekRegExp(TokenType.Hash, /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$/g)) {
 			let node = this.create(nodes.HexColorValue);
 			this.consumeToken();
 			return this.finish(node);

--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -524,10 +524,10 @@ export class LintVisitor implements nodes.IVisitor {
 
 	private visitUnknownNode(node: nodes.Node): boolean {
 
-		// Rule: #eeff00 or #ef0
+		// Rule: #eeff0011 or #eeff00 or #ef01 or #ef0 
 		if (node.type === nodes.NodeType.HexColorValue) {
 			let text = node.getText();
-			if (text.length !== 7 && text.length !== 4) {
+			if (text.length !== 9 && text.length !== 7 && text.length !== 5 && text.length !== 4) {
 				this.addEntry(node, Rules.HexColorLength);
 			}
 		}

--- a/src/services/lintRules.ts
+++ b/src/services/lintRules.ts
@@ -29,7 +29,7 @@ export let Rules = {
 	UniversalSelector: new Rule('universalSelector', localize('rule.universalSelector', "The universal selector (*) is known to be slow"), Ignore),
 	ZeroWithUnit: new Rule('zeroUnits', localize('rule.zeroWidthUnit', "No unit for zero needed"), Ignore),
 	RequiredPropertiesForFontFace: new Rule('fontFaceProperties', localize('rule.fontFaceProperties', "@font-face rule must define 'src' and 'font-family' properties"), Warning),
-	HexColorLength: new Rule('hexColorLength', localize('rule.hexColor', "Hex colors must consist of three or six hex numbers"), Error),
+	HexColorLength: new Rule('hexColorLength', localize('rule.hexColor', "Hex colors must consist of three, four, six or eight hex numbers"), Error),
 	ArgsInColorFunction: new Rule('argumentsInColorFunction', localize('rule.colorFunction', "Invalid number of parameters"), Error),
 	UnknownProperty: new Rule('unknownProperties', localize('rule.unknownProperty', "Unknown property."), Warning),
 	IEStarHack: new Rule('ieHack', localize('rule.ieHack', "IE hacks are only necessary when supporting IE7 and older"), Ignore),

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -393,7 +393,9 @@ suite('CSS - Parser', () => {
 	test('hexcolor', function () {
 		let parser = new Parser();
 		assertNode('#FFF', parser, parser._parseHexColor.bind(parser));
+		assertNode('#FFFF', parser, parser._parseHexColor.bind(parser));
 		assertNode('#FFFFFF', parser, parser._parseHexColor.bind(parser));
+		assertNode('#FFFFFFFF', parser, parser._parseHexColor.bind(parser));
 	});
 
 	test('Test class', function () {


### PR DESCRIPTION
fix: #32 

Note.
This doesn't show any color in small color box in the editor beside the color definition because css itself doesn't support it at the moment.

We could get around that problem by detecting and converting `#rgba` or `#rrggbbaa` values to `rgba()` values before they are added to `css/client/src/colorDecorators.ts`.

@aeschli - please correct me if I missed something. Very new to the source code.