### PR TITLE
Emmet integration in css language service

### DIFF
--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -10,7 +10,7 @@ import {
 } from 'vscode-languageserver-types';
 
 import { Parser } from './parser/cssParser';
-import { CSSCompletion } from './services/cssCompletion';
+import { CSSCompletion, ICompletionParticipant } from './services/cssCompletion';
 import { CSSHover } from './services/cssHover';
 import { CSSNavigation } from './services/cssNavigation';
 import { CSSCodeActions } from './services/cssCodeActions';
@@ -58,7 +58,7 @@ export interface LanguageService {
 	doValidation(document: TextDocument, stylesheet: Stylesheet, documentSettings?: LanguageSettings): Diagnostic[];
 	parseStylesheet(document: TextDocument): Stylesheet;
 	doComplete(document: TextDocument, position: Position, stylesheet: Stylesheet): CompletionList | null;
-	setEmmetCallback(callback: () => void): void;
+	setCompletionParticipants(registeredCompletionParticipants: ICompletionParticipant[]): void;
 	doHover(document: TextDocument, position: Position, stylesheet: Stylesheet): Hover | null;
 	findDefinition(document: TextDocument, position: Position, stylesheet: Stylesheet): Location | null;
 	findReferences(document: TextDocument, position: Position, stylesheet: Stylesheet): Location[];
@@ -86,7 +86,7 @@ function createFacade(parser: Parser, completion: CSSCompletion, hover: CSSHover
 		doValidation: validation.doValidation.bind(validation),
 		parseStylesheet: parser.parseStylesheet.bind(parser),
 		doComplete: completion.doComplete.bind(completion),
-		setEmmetCallback: completion.setEmmetCallback.bind(completion),
+		setCompletionParticipants: completion.setCompletionParticipants.bind(completion),
 		doHover: hover.doHover.bind(hover),
 		findDefinition: navigation.findDefinition.bind(navigation),
 		findReferences: navigation.findReferences.bind(navigation),

--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -10,7 +10,7 @@ import {
 } from 'vscode-languageserver-types';
 
 import { Parser } from './parser/cssParser';
-import { CSSCompletion, ICompletionParticipant } from './services/cssCompletion';
+import { CSSCompletion } from './services/cssCompletion';
 import { CSSHover } from './services/cssHover';
 import { CSSNavigation } from './services/cssNavigation';
 import { CSSCodeActions } from './services/cssCodeActions';
@@ -51,6 +51,11 @@ export interface ColorPresentation {
 	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
 	 */
 	additionalTextEdits?: TextEdit[];
+}
+
+export interface ICompletionParticipant {
+	onCssProperty: (propertyName: string, propertyValue?: string) => void;
+	onCssPropertyValue: (propertyName: string, propertyValue?: string) => void;
 }
 
 export interface LanguageService {

--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -53,9 +53,15 @@ export interface ColorPresentation {
 	additionalTextEdits?: TextEdit[];
 }
 
+export interface IPropertyContext {
+	propertyName: string;
+	propertyValue?: string;
+	range: Range;
+}
+
 export interface ICompletionParticipant {
-	onCssProperty: (propertyName: string, propertyValue?: string) => void;
-	onCssPropertyValue: (propertyName: string, propertyValue?: string) => void;
+	onCssProperty: (context: IPropertyContext) => void;
+	onCssPropertyValue: (context: IPropertyContext) => void;
 }
 
 export interface LanguageService {

--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -58,6 +58,7 @@ export interface LanguageService {
 	doValidation(document: TextDocument, stylesheet: Stylesheet, documentSettings?: LanguageSettings): Diagnostic[];
 	parseStylesheet(document: TextDocument): Stylesheet;
 	doComplete(document: TextDocument, position: Position, stylesheet: Stylesheet): CompletionList | null;
+	setEmmetCallback(callback: () => void): void;
 	doHover(document: TextDocument, position: Position, stylesheet: Stylesheet): Hover | null;
 	findDefinition(document: TextDocument, position: Position, stylesheet: Stylesheet): Location | null;
 	findReferences(document: TextDocument, position: Position, stylesheet: Stylesheet): Location[];
@@ -85,6 +86,7 @@ function createFacade(parser: Parser, completion: CSSCompletion, hover: CSSHover
 		doValidation: validation.doValidation.bind(validation),
 		parseStylesheet: parser.parseStylesheet.bind(parser),
 		doComplete: completion.doComplete.bind(completion),
+		setEmmetCallback: completion.setEmmetCallback.bind(completion),
 		doHover: hover.doHover.bind(hover),
 		findDefinition: navigation.findDefinition.bind(navigation),
 		findReferences: navigation.findReferences.bind(navigation),

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -60,7 +60,10 @@ export class CSSCompletion {
 				if (node instanceof nodes.Property) {
 					this.getCompletionsForDeclarationProperty(node.getParent() as nodes.Declaration, result);
 					this.completionParticipants.forEach(participant => {
-						participant.onCssProperty(this.currentWord);
+						participant.onCssProperty({
+							propertyName: this.currentWord,
+							range: this.defaultReplaceRange
+						});
 					});
 				} else if (node instanceof nodes.Expression) {
 					this.getCompletionsForExpression(<nodes.Expression>node, result);
@@ -187,7 +190,11 @@ export class CSSCompletion {
 		}
 
 		this.completionParticipants.forEach(participant => {
-			participant.onCssPropertyValue(propertyName, this.currentWord);
+			participant.onCssPropertyValue({
+				propertyName, 
+				propertyValue: this.currentWord, 
+				range: this.getCompletionRange(existingNode)
+			});
 		});
 
 		if (entry) {

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -402,7 +402,7 @@ export class CSSCompletion {
 				kind: CompletionItemKind.Function
 			});
 		}
-		if (hexColorRegex.test(this.currentWord)){
+		if (hexColorRegex.test(this.currentWord) && this.emmetCallback){
 			this.emmetCallback();
 		}
 		return result;

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -10,15 +10,11 @@ import * as languageFacts from './languageFacts';
 import * as strings from '../utils/strings';
 import { findFirst } from '../utils/arrays';
 import { TextDocument, Position, CompletionList, CompletionItem, CompletionItemKind, Range, TextEdit, InsertTextFormat } from 'vscode-languageserver-types';
+import { ICompletionParticipant } from '../cssLanguageService';
 
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 const SnippetFormat = InsertTextFormat.Snippet;
-
-export interface ICompletionParticipant {
-	onProperty: (propertyName: string, propertyValue?: string) => void;
-	onPropertyValue: (propertyName: string, propertyValue?: string) => void;
-}
 
 export class CSSCompletion {
 
@@ -64,7 +60,7 @@ export class CSSCompletion {
 				if (node instanceof nodes.Property) {
 					this.getCompletionsForDeclarationProperty(node.getParent() as nodes.Declaration, result);
 					this.completionParticipants.forEach(participant => {
-						participant.onProperty((<nodes.Property>node).getName());
+						participant.onCssProperty(this.currentWord);
 					});
 				} else if (node instanceof nodes.Expression) {
 					this.getCompletionsForExpression(<nodes.Expression>node, result);
@@ -191,7 +187,7 @@ export class CSSCompletion {
 		}
 
 		this.completionParticipants.forEach(participant => {
-			participant.onPropertyValue(propertyName, this.currentWord);
+			participant.onCssPropertyValue(propertyName, this.currentWord);
 		});
 
 		if (entry) {


### PR DESCRIPTION
Emmet completions need to be included in 2 places in a css file
- When typing a css property name
- When typing a value for a css property which expects color and what is being typed is hex color code

To keep the language service light and to avoid adding a emmet dependency (in umd) which needs to be maintained, this PR makes use of a callback model to get emmet completions.
