### PR TITLE
Update the exported type for Stylesheet

### DIFF
--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -21,7 +21,11 @@ import { SCSSCompletion } from './services/scssCompletion';
 import { LESSParser } from './parser/lessParser';
 import { LESSCompletion } from './services/lessCompletion';
 
-export type Stylesheet = {};
+export type Stylesheet = {
+	offset: number;
+	length: number;
+	end: number;
+};
 export { TextEdit, Range };
 
 export interface Color {


### PR DESCRIPTION
@aeschli 

To workaround #69, I need to know the `end` property of the stylesheet. This PR is to expose it in the exported type.

P.S: I noticed that we have already published 3.0.7 version of this module, but the `package.json` still has 3.0.6. Also the package-lock.json has a lot of changes locally when I run `npm install`. Any reason we don't want to commit those changes?