### PR TITLE
Allow full expression in interpolation. Fix Microsoft/vscode#44331

### DIFF
--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -165,6 +165,9 @@ export class SCSSParser extends cssParser.Parser {
 			let node = this.create(nodes.Interpolation);
 			this.consumeToken();
 			if (!node.addChild(this._parseExpr()) && !this._parseSelectorCombinator()) {
+				if (this.accept(TokenType.CurlyR)) {
+					return this.finish(node);
+				}
 				return this.finish(node, ParseError.ExpressionExpected);
 			}
 			if (!this.accept(TokenType.CurlyR)) {

--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -164,7 +164,7 @@ export class SCSSParser extends cssParser.Parser {
 		if (this.peek(scssScanner.InterpolationFunction)) {
 			let node = this.create(nodes.Interpolation);
 			this.consumeToken();
-			if (!node.addChild(this._parseBinaryExpr()) && !this._parseSelectorCombinator()) {
+			if (!node.addChild(this._parseExpr()) && !this._parseSelectorCombinator()) {
 				return this.finish(node, ParseError.ExpressionExpected);
 			}
 			if (!this.accept(TokenType.CurlyR)) {

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -60,7 +60,11 @@ export class CSSCompletion {
 				if (node instanceof nodes.Property) {
 					this.getCompletionsForDeclarationProperty(node.getParent() as nodes.Declaration, result);
 				} else if (node instanceof nodes.Expression) {
-					this.getCompletionsForExpression(<nodes.Expression>node, result);
+					if (node.parent instanceof nodes.Interpolation) {
+						this.getVariableProposals(null, result);
+					} else {
+						this.getCompletionsForExpression(<nodes.Expression>node, result);
+					}
 				} else if (node instanceof nodes.SimpleSelector) {
 					let parentExtRef = <nodes.ExtendsReference>node.findParent(nodes.NodeType.ExtendsReference);
 					if (parentExtRef) {
@@ -93,6 +97,8 @@ export class CSSCompletion {
 					this.getCompletionsForExtendsReference(<nodes.ExtendsReference>node, null, result);
 				} else if (node.type === nodes.NodeType.URILiteral) {
 					this.getCompletionForUriLiteralValue(node, result);
+				// } else if (node instanceof nodes.Variable) {
+					// this.getCompletionsForVariableDeclaration()
 				} else {
 					continue;
 				}

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -112,7 +112,7 @@ suite('SCSS - Parser', () => {
 		assertNode('&:nth-child(#{$query}+1) { clear: $opposite-direction; }', parser, parser._parseRuleset.bind(parser));
 		assertNode('--#{$propname}: some-value', parser, parser._parseDeclaration.bind(parser));
 		assertNode('some-property: var(--#{$propname})', parser, parser._parseDeclaration.bind(parser));
-		assertError('#{}', parser, parser._parseIdent.bind(parser), ParseError.ExpressionExpected);
+		assertNode('#{}', parser, parser._parseIdent.bind(parser));
 		assertError('#{1 + 2', parser, parser._parseIdent.bind(parser), ParseError.RightCurlyExpected);
 	});
 

--- a/src/test/scss/scssCompletion.test.ts
+++ b/src/test/scss/scssCompletion.test.ts
@@ -39,6 +39,11 @@ suite('SCSS - Completions', () => {
 				{ label: '$i', documentation: '0' }
 			]
 		});
+		testCompletionFor('@for $i from 1 through 3 { .item-#{|} { width: 2em * $i; } }', {
+			items: [
+				{ label: '$i' }
+			]
+		});
 		testCompletionFor('@for $i from 1 through 3 { .item-#{|$i} { width: 2em * $i; } }', {
 			items: [
 				{ label: '$i' }


### PR DESCRIPTION
This breaks a test here

```ts
testCompletionFor('@for $i from 1 through 3 { .item-#{|$i} { width: 2em * $i; } }', {
	items: [
		{ label: '$i' }
	]
});
```

However I'm wondering why we have test for this
```scss
@for $i from 1 through 3 {
  .item-#{|$i} { width: 2em * $i; }
}
```

but not these, which are far more common completion than the first one

```scss
@for $i from 1 through 3 {
  .item-#{|} { width: 2em * $i; }
}
```

```scss
@for $i from 1 through 3 {
  .item-#{$|} { width: 2em * $i; }
}
```