### PR TITLE
Update display of supported browsers for CSS properties on-hover.

### DIFF
--- a/src/services/languageFacts.ts
+++ b/src/services/languageFacts.ts
@@ -595,7 +595,7 @@ export function getEntryDescription(entry: { description: string; browsers: Brow
 
 	let browserLabel = getBrowserLabel(entry.browsers);
 	if (browserLabel) {
-		desc += '\n(' + browserLabel + ')';
+		desc += '\n\nBrowser Support: ' + browserLabel;
 	}
 	if (entry.data && entry.data.syntax) {
 		desc += `\n\nSyntax: ${entry.data.syntax}`;


### PR DESCRIPTION
I wanted to try messing around with extension development, but more importantly I wanted it clear what the browsers list is supposed to mean.

Old style: '(Chrome 31, Firefox 27, IE 11, Edge)'
New style: 'Browser Support: Chrome 31, Firefox 27, IE 11, Edge'

Before:

<img width="808" alt="screen shot 2018-06-06 at 4 14 47 pm" src="https://user-images.githubusercontent.com/2977353/41067996-e26619c8-69a4-11e8-8ff7-67e7b9a63037.png">

After:

<img width="795" alt="screen shot 2018-06-06 at 4 14 19 pm" src="https://user-images.githubusercontent.com/2977353/41067994-e24a2b28-69a4-11e8-9b1e-da55a0017ae6.png">