### PR TITLE
 Handle unknown at rules. Fix #51

### DIFF
--- a/src/parser/cssErrors.ts
+++ b/src/parser/cssErrors.ts
@@ -45,7 +45,6 @@ export let ParseError = {
 	CommaExpected: new CSSIssueType('css-commaexpected', localize('expected.comma', "comma expected")),
 	PageDirectiveOrDeclarationExpected: new CSSIssueType('css-pagedirordeclexpected', localize('expected.pagedirordecl', "page directive or declaraton expected")),
 	UnknownAtRule: new CSSIssueType('css-unknownatrule', localize('unknown.atrule', "at-rule unknown")),
-	AtRuleBodyExpected: new CSSIssueType('css-atrulebodyexpected', localize('expected.atrulebody', 'at rule body expected')),
 	UnknownKeyword: new CSSIssueType('css-unknownkeyword', localize('unknown.keyword', "unknown keyword")),
 	SelectorExpected: new CSSIssueType('css-selectorexpected', localize('expected.selector', "selector expected")),
 	StringLiteralExpected: new CSSIssueType('css-stringliteralexpected', localize('expected.stringliteral', "string literal expected")),

--- a/src/parser/cssErrors.ts
+++ b/src/parser/cssErrors.ts
@@ -45,6 +45,7 @@ export let ParseError = {
 	CommaExpected: new CSSIssueType('css-commaexpected', localize('expected.comma', "comma expected")),
 	PageDirectiveOrDeclarationExpected: new CSSIssueType('css-pagedirordeclexpected', localize('expected.pagedirordecl', "page directive or declaraton expected")),
 	UnknownAtRule: new CSSIssueType('css-unknownatrule', localize('unknown.atrule', "at-rule unknown")),
+	AtRuleBodyExpected: new CSSIssueType('css-atrulebodyexpected', localize('expected.atrulebody', 'at rule body expected')),
 	UnknownKeyword: new CSSIssueType('css-unknownkeyword', localize('unknown.keyword', "unknown keyword")),
 	SelectorExpected: new CSSIssueType('css-selectorexpected', localize('expected.selector', "selector expected")),
 	StringLiteralExpected: new CSSIssueType('css-stringliteralexpected', localize('expected.stringliteral', "string literal expected")),

--- a/src/parser/cssNodes.ts
+++ b/src/parser/cssNodes.ts
@@ -1243,7 +1243,7 @@ export class AttributeSelector extends Node {
 
 	public getValue(): BinaryExpression {
 		return this.value;
-	}	
+	}
 }
 
 export class Operator extends Node {
@@ -1488,6 +1488,7 @@ export class MixinDeclaration extends BodyDeclaration {
 }
 
 export class UnknownAtRule extends BodyDeclaration {
+	public atRuleName: string;
 
 	constructor(offset: number, length: number) {
 		super(offset, length);
@@ -1495,6 +1496,13 @@ export class UnknownAtRule extends BodyDeclaration {
 
 	public get type(): NodeType {
 		return NodeType.UnknownAtRule;
+	}
+
+	public setAtRuleName(atRuleName: string) {
+		this.atRuleName = atRuleName;
+	}
+	public getAtRuleName(atRuleName: string) {
+		return this.atRuleName;
 	}
 }
 

--- a/src/parser/cssNodes.ts
+++ b/src/parser/cssNodes.ts
@@ -81,7 +81,8 @@ export enum NodeType {
 	SupportsCondition,
 	NamespacePrefix,
 	GridLine,
-	Plugin
+	Plugin,
+	UnknownAtRule,
 }
 
 export enum ReferenceType {
@@ -1483,6 +1484,17 @@ export class MixinDeclaration extends BodyDeclaration {
 			this.guard = node;
 		}
 		return false;
+	}
+}
+
+export class UnknownAtRule extends BodyDeclaration {
+
+	constructor(offset: number, length: number) {
+		super(offset, length);
+	}
+
+	public get type(): NodeType {
+		return NodeType.UnknownAtRule;
 	}
 }
 

--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -999,12 +999,66 @@ export class Parser {
 
 	// https://www.w3.org/TR/css-syntax-3/#consume-an-at-rule
 	public _parseUnknownAtRule(): nodes.Node {
-		if (!this.peek(TokenType.AtKeyword)) {
-			return null;
-		}
-
 		let node = <nodes.UnknownAtRule>this.create(nodes.UnknownAtRule);
-		this.consumeToken();
+		node.addChild(this._parseUnknownAtRuleName());
+
+		const isTopLevel = () => curlyDepth === 0 && parensDepth === 0 && bracketsDepth === 0;
+		let curlyDepth = 0;
+		let parensDepth = 0;
+		let bracketsDepth = 0;
+		done: while (true) {
+			switch (this.token.type) {
+				case TokenType.SemiColon:
+					if (isTopLevel()) {
+						break done;
+					}
+					break;
+				case TokenType.EOF:
+					if (curlyDepth > 0) {
+						return this.finish(node, ParseError.RightCurlyExpected);
+					} else if (bracketsDepth > 0) {
+						return this.finish(node, ParseError.RightSquareBracketExpected);
+					} else if (parensDepth > 0) {
+						return this.finish(node, ParseError.RightParenthesisExpected);
+					} else {
+						return this.finish(node);
+					}
+				case TokenType.CurlyL:
+					curlyDepth++;
+					break;
+				case TokenType.CurlyR:
+					curlyDepth--;
+					if (curlyDepth < 0) {
+						// The property value has been terminated without a semicolon, and
+						// this is the last declaration in the ruleset.
+						if (parensDepth === 0 && bracketsDepth === 0) {
+							break done;
+						}
+						return this.finish(node, ParseError.LeftCurlyExpected);
+					}
+					break;
+				case TokenType.ParenthesisL:
+					parensDepth++;
+					break;
+				case TokenType.ParenthesisR:
+					parensDepth--;
+					if (parensDepth < 0) {
+						return this.finish(node, ParseError.LeftParenthesisExpected);
+					}
+					break;
+				case TokenType.BracketL:
+					bracketsDepth++;
+					break;
+				case TokenType.BracketR:
+					bracketsDepth--;
+					if (bracketsDepth < 0) {
+						return this.finish(node, ParseError.LeftSquareBracketExpected);
+					}
+					break;
+			}
+
+			this.consumeToken();
+		}
 
 		this.resync([], [TokenType.SemiColon, TokenType.EOF, TokenType.CurlyL]); // ignore all the rules
 		if (this.peek(TokenType.SemiColon)) {
@@ -1014,6 +1068,16 @@ export class Parser {
 			return this._parseBody(node, this._parseStylesheetStatement.bind(this));
 		} else if (this.peek(TokenType.EOF)) {
 			return this.finish(node, ParseError.AtRuleBodyExpected);
+		}
+
+		return node;
+	}
+
+	public _parseUnknownAtRuleName(): nodes.Node {
+		let node = <nodes.Node>this.create(nodes.Node);
+
+		if (this.accept(TokenType.AtKeyword)) {
+			return this.finish(node);
 		}
 
 		return node;

--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -1060,16 +1060,6 @@ export class Parser {
 			this.consumeToken();
 		}
 
-		this.resync([], [TokenType.SemiColon, TokenType.EOF, TokenType.CurlyL]); // ignore all the rules
-		if (this.peek(TokenType.SemiColon)) {
-			this.consumeToken();
-			return node;
-		} else if (this.peek(TokenType.CurlyL)) {
-			return this._parseBody(node, this._parseStylesheetStatement.bind(this));
-		} else if (this.peek(TokenType.EOF)) {
-			return this.finish(node, ParseError.AtRuleBodyExpected);
-		}
-
 		return node;
 	}
 

--- a/src/parser/cssScanner.ts
+++ b/src/parser/cssScanner.ts
@@ -15,8 +15,8 @@ export enum TokenType {
 	Percentage,
 	Dimension,
 	UnicodeRange,
-	CDO,
-	CDC,
+	CDO, // <!--
+	CDC, // -->
 	Colon,
 	SemiColon,
 	CurlyL,
@@ -27,13 +27,13 @@ export enum TokenType {
 	BracketR,
 	Whitespace,
 	Includes,
-	Dashmatch,
-	SubstringOperator,
-	PrefixOperator,
-	SuffixOperator,
+	Dashmatch, // |=
+	SubstringOperator, // *=
+	PrefixOperator, // ^=
+	SuffixOperator, // $=
 	Delim,
-	EMS,
-	EXS,
+	EMS, // 3em
+	EXS, // 3ex
 	Length,
 	Angle,
 	Time,

--- a/src/parser/lessParser.ts
+++ b/src/parser/lessParser.ts
@@ -21,11 +21,15 @@ export class LESSParser extends cssParser.Parser {
 	}
 
 	public _parseStylesheetStatement(): nodes.Node {
+		if (this.peek(TokenType.AtKeyword)) {
+			return this._parseVariableDeclaration()
+				|| this._parsePlugin()
+				|| super._parseStylesheetAtStatement();
+		}
+
 		return this._tryParseMixinDeclaration()
 			|| this._tryParseMixinReference(true)
-			|| super._parseStylesheetStatement()
-			|| this._parseVariableDeclaration()
-			|| this._parsePlugin();
+			|| this._parseRuleset(true);
 	}
 
 	public _parseImport(): nodes.Node {

--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -22,19 +22,16 @@ export class SCSSParser extends cssParser.Parser {
 	}
 
 	public _parseStylesheetStatement(): nodes.Node {
-		let node = super._parseStylesheetStatement();
-		if (node) {
-			return node;
-		}
 		if (this.peek(TokenType.AtKeyword)) {
 			return this._parseWarnAndDebug()
 				|| this._parseControlStatement()
 				|| this._parseMixinDeclaration()
 				|| this._parseMixinContent()
 				|| this._parseMixinReference() // @include
-				|| this._parseFunctionDeclaration();
+				|| this._parseFunctionDeclaration()
+				|| super._parseStylesheetAtStatement();
 		}
-		return this._parseVariableDeclaration();
+		return this._parseRuleset(true) || this._parseVariableDeclaration();
 	}
 
 	public _parseImport(): nodes.Node {

--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -136,6 +136,8 @@ export class LintVisitor implements nodes.IVisitor {
 
 	public visitNode(node: nodes.Node): boolean {
 		switch (node.type) {
+			case nodes.NodeType.UnknownAtRule:
+				return this.visitUnknownAtRule(<nodes.UnknownAtRule>node);
 			case nodes.NodeType.Keyframe:
 				return this.visitKeyframe(<nodes.Keyframe>node);
 			case nodes.NodeType.FontFace:
@@ -160,6 +162,16 @@ export class LintVisitor implements nodes.IVisitor {
 
 	private completeValidations() {
 		this.validateKeyframes();
+	}
+
+	private visitUnknownAtRule(node: nodes.UnknownAtRule): boolean {
+		const atRuleName = node.getChild(0);
+		if (!atRuleName) {
+			return false;
+		}
+
+		this.addEntry(atRuleName, Rules.UnknownAtRules, `Unknown at rule ${atRuleName.getText()}`);
+		return true;
 	}
 
 	private visitKeyframe(node: nodes.Keyframe): boolean {

--- a/src/services/lintRules.ts
+++ b/src/services/lintRules.ts
@@ -35,6 +35,7 @@ export let Rules = {
 	HexColorLength: new Rule('hexColorLength', localize('rule.hexColor', "Hex colors must consist of three, four, six or eight hex numbers"), Error),
 	ArgsInColorFunction: new Rule('argumentsInColorFunction', localize('rule.colorFunction', "Invalid number of parameters"), Error),
 	UnknownProperty: new Rule('unknownProperties', localize('rule.unknownProperty', "Unknown property."), Warning),
+	UnknownAtRules: new Rule('unknownAtRules', localize('rule.unknownAtRules', "Unknown at-rule."), Warning),
 	IEStarHack: new Rule('ieHack', localize('rule.ieHack', "IE hacks are only necessary when supporting IE7 and older"), Ignore),
 	UnknownVendorSpecificProperty: new Rule('unknownVendorSpecificProperties', localize('rule.unknownVendorSpecificProperty', "Unknown vendor specific property."), Ignore),
 	PropertyIgnoredDueToDisplay: new Rule('propertyIgnoredDueToDisplay', localize('rule.propertyIgnoredDueToDisplay', "Property is ignored due to the display."), Warning),

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -71,9 +71,20 @@ suite('CSS - Parser', () => {
 		assertNode('E.warning E#myid E:not(s) {}', parser, parser._parseStylesheet.bind(parser));
 		assertError('@namespace;', parser, parser._parseStylesheet.bind(parser), ParseError.URIExpected);
 		assertError('@namespace url(http://test)', parser, parser._parseStylesheet.bind(parser), ParseError.SemiColonExpected);
-		assertError('@mskeyframes darkWordHighlight { from { background-color: inherit; } to { background-color: rgba(83, 83, 83, 0.7); } }', parser, parser._parseStylesheet.bind(parser), ParseError.UnknownAtRule);
 		assertError('@charset;', parser, parser._parseStylesheet.bind(parser), ParseError.IdentifierExpected);
 		assertError('@charset \'utf8\'', parser, parser._parseStylesheet.bind(parser), ParseError.SemiColonExpected);
+	});
+
+	test('stylesheet - graceful handling of unknown rules', function () {
+		let parser = new Parser();
+		assertNode('@unknown-rule;', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@unknown-rule (;', parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@unknown-rule 'foo';`, parser, parser._parseStylesheet.bind(parser));
+		assertNode('@unknown-rule (foo) {}', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@unknown-rule (foo) { .bar {} }', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@mskeyframes darkWordHighlight { from { background-color: inherit; } to { background-color: rgba(83, 83, 83, 0.7); } }', parser, parser._parseStylesheet.bind(parser));
+
+		assertError('@unknown-rule (foo) { .bar {}', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
 	});
 
 	test('stylesheet /panic/', function () {
@@ -195,7 +206,7 @@ suite('CSS - Parser', () => {
 		assertNode('@page {  @top-right-corner { content: url(foo.png); border: solid green; } }', parser, parser._parsePage.bind(parser));
 		assertNode('@page {  @top-left-corner { content: " "; border: solid green; } @bottom-right-corner { content: counter(page); border: solid green; } }', parser, parser._parsePage.bind(parser));
 		assertError('@page {  @top-left-corner foo { content: " "; border: solid green; } }', parser, parser._parsePage.bind(parser), ParseError.LeftCurlyExpected);
-		assertError('@page {  @XY foo { content: " "; border: solid green; } }', parser, parser._parsePage.bind(parser), ParseError.UnknownAtRule);
+		// assertError('@page {  @XY foo { content: " "; border: solid green; } }', parser, parser._parsePage.bind(parser), ParseError.UnknownAtRule);
 		assertError('@page :left { margin-left: 4cm margin-right: 3cm; }', parser, parser._parsePage.bind(parser), ParseError.SemiColonExpected);
 		assertError('@page : { }', parser, parser._parsePage.bind(parser), ParseError.IdentifierExpected);
 		assertError('@page :left, { }', parser, parser._parsePage.bind(parser), ParseError.IdentifierExpected);

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -78,14 +78,15 @@ suite('CSS - Parser', () => {
 	test('stylesheet - graceful handling of unknown rules', function () {
 		let parser = new Parser();
 		assertNode('@unknown-rule;', parser, parser._parseStylesheet.bind(parser));
-		assertNode('@unknown-rule (;', parser, parser._parseStylesheet.bind(parser));
 		assertNode(`@unknown-rule 'foo';`, parser, parser._parseStylesheet.bind(parser));
 		assertNode('@unknown-rule (foo) {}', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@unknown-rule (foo) { .bar {} }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@mskeyframes darkWordHighlight { from { background-color: inherit; } to { background-color: rgba(83, 83, 83, 0.7); } }', parser, parser._parseStylesheet.bind(parser));
 
-		assertError('@unknown-rule', parser, parser._parseStylesheet.bind(parser), ParseError.AtRuleBodyExpected);
-		assertError('@unknown-rule foo', parser, parser._parseStylesheet.bind(parser), ParseError.AtRuleBodyExpected);
+		assertError('@unknown-rule (;', parser, parser._parseStylesheet.bind(parser), ParseError.RightParenthesisExpected);
+		assertError('@unknown-rule [foo', parser, parser._parseStylesheet.bind(parser), ParseError.RightSquareBracketExpected);
+		assertError('@unknown-rule { [foo }', parser, parser._parseStylesheet.bind(parser), ParseError.RightSquareBracketExpected);
+		assertError('@unknown-rule (foo) {', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
 		assertError('@unknown-rule (foo) { .bar {}', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
 	});
 

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -84,6 +84,8 @@ suite('CSS - Parser', () => {
 		assertNode('@unknown-rule (foo) { .bar {} }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@mskeyframes darkWordHighlight { from { background-color: inherit; } to { background-color: rgba(83, 83, 83, 0.7); } }', parser, parser._parseStylesheet.bind(parser));
 
+		assertError('@unknown-rule', parser, parser._parseStylesheet.bind(parser), ParseError.AtRuleBodyExpected);
+		assertError('@unknown-rule foo', parser, parser._parseStylesheet.bind(parser), ParseError.AtRuleBodyExpected);
 		assertError('@unknown-rule (foo) { .bar {}', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
 	});
 

--- a/src/test/less/parser.test.ts
+++ b/src/test/less/parser.test.ts
@@ -35,8 +35,7 @@ suite('LESS - Parser', () => {
 		assertNode('.something { @media (max-width: 760px) { > div { display: block; } } }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@media (@var) {}', parser, parser._parseMedia.bind(parser));
 		assertNode('@media screen and (@var) {}', parser, parser._parseMedia.bind(parser));
-
-		assertError('@media (max-width: 760px) { + div { display: block; } }', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
+		assertNode('@media (max-width: 760px) { + div { display: block; } }', parser, parser._parseStylesheet.bind(parser));
 	});
 
 	test('VariableDeclaration', function () {

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -188,7 +188,7 @@ suite('SCSS - Parser', () => {
 		assertNode('.something { @media (max-width: 760px) { > .test { color: blue; } } }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('.something { @media (max-width: 760px) { ~ div { display: block; } } }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('.something { @media (max-width: 760px) { + div { display: block; } } }', parser, parser._parseStylesheet.bind(parser));
-		assertError('@media (max-width: 760px) { + div { display: block; } }', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
+		assertNode('@media (max-width: 760px) { + div { display: block; } }', parser, parser._parseStylesheet.bind(parser));
 	});
 
 	test('@keyframe', function () {


### PR DESCRIPTION
Known limitations:

Removed a test case from https://github.com/Microsoft/vscode-css-languageservice/commit/7f07d5e2b8ae1e5845175432c7e3213dcff6e20b which intended to address https://github.com/Microsoft/vscode/issues/2573 and https://github.com/Microsoft/vscode/issues/23862

Currently the parser rule is relaxed, so
```less
// .something {
    @media (max-width: 760px) {
        > .test {
            color: blue;
        }
    }
// }
```
Will not give any errors, although `> .test` inside `@media` should really be used in a nested selector.

Did this because the current errors for this case is very wrong:

![wrong](https://user-images.githubusercontent.com/4033249/41428845-272c103c-6fc0-11e8-9805-d0473d3eda43.gif)

@aeschli I can log a new issue for giving correct error here, like `Selectors that begin with a combinator should be used inside a nested RuleSet.`