### PR TITLE
Add CSS Lint Rule name to lint markers.

### DIFF
--- a/src/services/cssValidation.ts
+++ b/src/services/cssValidation.ts
@@ -35,7 +35,7 @@ export class CSSValidation {
 			return <Diagnostic>{
 				code: marker.getRule().id,
 				source: document.languageId,
-				message: marker.getMessage(),
+				message: `${marker.getMessage()} (${marker.getRule().id})`,
 				severity: marker.getLevel() === nodes.Level.Warning ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error,
 				range: range
 			};


### PR DESCRIPTION
Resolves https://github.com/Microsoft/vscode/issues/56925

Before:
<img width="475" alt="screen shot 2018-08-21 at 2 16 06 pm" src="https://user-images.githubusercontent.com/2977353/44426783-cbcb5c80-a54c-11e8-82fc-97f308548a8b.png">
<img width="612" alt="screen shot 2018-08-21 at 2 16 15 pm" src="https://user-images.githubusercontent.com/2977353/44426784-cbcb5c80-a54c-11e8-972e-14a7c9680278.png">


After:
<img width="656" alt="screen shot 2018-08-21 at 2 10 55 pm" src="https://user-images.githubusercontent.com/2977353/44426719-a3dbf900-a54c-11e8-941c-f622c1f14466.png">
<img width="599" alt="screen shot 2018-08-21 at 2 11 09 pm" src="https://user-images.githubusercontent.com/2977353/44426721-a3dbf900-a54c-11e8-9ded-2cd12d550d47.png">

The rule name doesn't include the `css.lint.*` prefix, but that isn't included in the Rule object that `marker.getRule()` returns. That can be worked around using `document.languageId` but I'm fairly sure that'd break on some edge cases.