### PR TITLE
Rename specificity label and add a link to MDN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "editor.insertSpaces": false
+  "editor.insertSpaces": false,
+  "prettier.useTabs": true,
+  "prettier.printWidth": 120,
+  "prettier.semi": true
 }

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -352,9 +352,7 @@ function selectorToSpecificityMarkedString(node: nodes.Node): MarkedString {
 
 	let specificity = [0, 0, 0]; //a,b,c
 	calculateScore(node);
-	return {
-		language: 'markdown', value: localize('specificity', "[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): ({0}, {1}, {2})", ...specificity)
-	};
+	return localize('specificity', "[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): ({0}, {1}, {2})", ...specificity);
 }
 
 export function selectorToMarkedString(node: nodes.Selector): MarkedString[] {

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -353,7 +353,7 @@ function selectorToSpecificityMarkedString(node: nodes.Node): MarkedString {
 	let specificity = [0, 0, 0]; //a,b,c
 	calculateScore(node);
 	return {
-		language: 'text', value: localize('specificity', "Specificity: ({0}, {1}, {2})", ...specificity)
+		language: 'markdown', value: localize('specificity', "[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): ({0}, {1}, {2})", ...specificity)
 	};
 }
 

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -28,7 +28,6 @@ function elementToString(element: selectorPrinter.Element): string {
 		label = label + ']';
 	}
 
-
 	if (element.children) {
 		label = label + '{';
 		for (let index = 0; index < element.children.length; index++) {
@@ -64,7 +63,12 @@ export function assertElement(p: Parser, input: string, expected: { name: string
 	assert.deepEqual(actual.attributes, expected);
 }
 
-export function parseSelectorToMarkedString(p: Parser, input: string, selectorName: string, expected: MarkedString[]): void {
+export function parseSelectorToMarkedString(
+	p: Parser,
+	input: string,
+	selectorName: string,
+	expected: MarkedString[]
+): void {
 	let selector = doParse(p, input, selectorName);
 	let printedElement = selectorPrinter.selectorToMarkedString(selector);
 
@@ -72,35 +76,37 @@ export function parseSelectorToMarkedString(p: Parser, input: string, selectorNa
 }
 
 suite('CSS - Selector Printing', () => {
-
-	test('class/hash/elementname/attr', function () {
+	test('class/hash/elementname/attr', function() {
 		let p = new Parser();
 		assertElement(p, 'element', [{ name: 'name', value: 'element' }]);
 		assertElement(p, '.div', [{ name: 'class', value: 'div' }]);
 		assertElement(p, '#first', [{ name: 'id', value: 'first' }]);
 		assertElement(p, 'element.on', [{ name: 'name', value: 'element' }, { name: 'class', value: 'on' }]);
-		assertElement(p, 'element.on#first', [{ name: 'name', value: 'element' }, { name: 'class', value: 'on' }, { name: 'id', value: 'first' }]);
+		assertElement(p, 'element.on#first', [
+			{ name: 'name', value: 'element' },
+			{ name: 'class', value: 'on' },
+			{ name: 'id', value: 'first' }
+		]);
 		assertElement(p, '.on#first', [{ name: 'class', value: 'on' }, { name: 'id', value: 'first' }]);
 
-		assertElement(p, '[lang=\'de\']', [{ name: 'lang', value: 'de' }]);
+		assertElement(p, "[lang='de']", [{ name: 'lang', value: 'de' }]);
 		assertElement(p, '[enabled]', [{ name: 'enabled', value: void 0 }]);
-
 	});
 
-	test('simple selector', function () {
+	test('simple selector', function() {
 		let p = new Parser();
 		parseSelector(p, 'element { }', 'element', '{element}');
 		parseSelector(p, 'element.div { }', 'element', '{element[class=div]}');
 		parseSelector(p, 'element.on#first { }', 'element', '{element[class=on|id=first]}');
 		parseSelector(p, 'element:hover { }', 'element', '{element[:hover=]}');
-		parseSelector(p, 'element[lang=\'de\'] { }', 'element', '{element[lang=de]}');
+		parseSelector(p, "element[lang='de'] { }", 'element', '{element[lang=de]}');
 		parseSelector(p, 'element[enabled] { }', 'element', '{element[enabled=undefined]}');
 		parseSelector(p, 'element[foo~="warning"] { }', 'element', '{element[foo= … warning … ]}');
 		parseSelector(p, 'element[lang|="en"] { }', 'element', '{element[lang=en-…]}');
 		parseSelector(p, '* { }', '*', '{element}');
 	});
 
-	test('selector', function () {
+	test('selector', function() {
 		let p = new Parser();
 		parseSelector(p, 'e1 e2 { }', 'e1', '{e1{…{e2}}}');
 		parseSelector(p, 'e1 .div { }', 'e1', '{e1{…{[class=div]}}}');
@@ -110,67 +116,119 @@ suite('CSS - Selector Printing', () => {
 		parseSelector(p, 'e1 ~ e2 { }', 'e2', '{e1|e2|⋮|e2}');
 	});
 
-	test('escaping', function () {
+	test('escaping', function() {
 		let p = new Parser();
 		parseSelector(p, '#\\34 04-error { }', '#\\34 04-error', '{[id=404-error]}');
-
 	});
 });
 
 suite('CSS - MarkedStringPrinter selectors', () => {
-
-	test('descendant selector', function () {
+	test('descendant selector', function() {
 		let p = new Parser();
-		parseSelectorToMarkedString(p, 'e1 e2 { }', 'e1', [{ language: 'html', value: '<e1>\n  …\n    <e2>' }, { language: 'text', value: 'Specificity: (0, 0, 2)'}]);
-		parseSelectorToMarkedString(p, 'e1 .div { }', 'e1', [{ language: 'html', value: '<e1>\n  …\n    <element class="div">' }, { language: 'text', value: 'Specificity: (0, 1, 1)'}]);
+		parseSelectorToMarkedString(p, 'e1 e2 { }', 'e1', [
+			{ language: 'html', value: '<e1>\n  …\n    <e2>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
+		parseSelectorToMarkedString(p, 'e1 .div { }', 'e1', [
+			{ language: 'html', value: '<e1>\n  …\n    <element class="div">' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+		]);
 	});
-	test('child selector', function () {
+	test('child selector', function() {
 		let p = new Parser();
-		parseSelectorToMarkedString(p, 'e1 > e2 { }', 'e2', [{ language: 'html', value: '<e1>\n  <e2>' }, { language: 'text', value: 'Specificity: (0, 0, 2)'}]);
+		parseSelectorToMarkedString(p, 'e1 > e2 { }', 'e2', [
+			{ language: 'html', value: '<e1>\n  <e2>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
 	});
-	test('group selector', function () {
+	test('group selector', function() {
 		let p = new Parser();
-		parseSelectorToMarkedString(p, 'e1, e2 { }', 'e1', [{ language: 'html', value: '<e1>' }, { language: 'text', value: 'Specificity: (0, 0, 1)'}]);
-		parseSelectorToMarkedString(p, 'e1, e2 { }', 'e2', [{ language: 'html', value: '<e2>' }, { language: 'text', value: 'Specificity: (0, 0, 1)'}]);
+		parseSelectorToMarkedString(p, 'e1, e2 { }', 'e1', [
+			{ language: 'html', value: '<e1>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+		]);
+		parseSelectorToMarkedString(p, 'e1, e2 { }', 'e2', [
+			{ language: 'html', value: '<e2>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+		]);
 	});
-	test('sibling selector', function () {
+	test('sibling selector', function() {
 		let p = new Parser();
-		parseSelectorToMarkedString(p, 'e1 + e2 { }', 'e2', [{ language: 'html', value: '<e1>\n<e2>' }, { language: 'text', value: 'Specificity: (0, 0, 2)'}]);
-		parseSelectorToMarkedString(p, 'e1 ~ e2 { }', 'e2', [{ language: 'html', value: '<e1>\n<e2>\n⋮\n<e2>' }, { language: 'text', value: 'Specificity: (0, 0, 2)'}]);
+		parseSelectorToMarkedString(p, 'e1 + e2 { }', 'e2', [
+			{ language: 'html', value: '<e1>\n<e2>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
+		parseSelectorToMarkedString(p, 'e1 ~ e2 { }', 'e2', [
+			{ language: 'html', value: '<e1>\n<e2>\n⋮\n<e2>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
 	});
 });
 
 suite('CSS - MarkedStringPrinter selectors specificities', () => {
 	let p = new Parser();
 	test('attribute selector', function() {
-		parseSelectorToMarkedString(p, 'h1 + *[rel=up]', 'h1', [{ language: 'html', value: '<h1>\n<element rel="up">' }, { language: 'text', value: 'Specificity: (0, 1, 1)' }]);
+		parseSelectorToMarkedString(p, 'h1 + *[rel=up]', 'h1', [
+			{ language: 'html', value: '<h1>\n<element rel="up">' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+		]);
 	});
-	
+
 	test('class selector', function() {
-		parseSelectorToMarkedString(p, 'ul ol li.red', 'ul', [{ language: 'html', value: '<ul>\n  …\n    <ol>\n      …\n        <li class="red">' }, { language: 'text', value: 'Specificity: (0, 1, 3)' }]);
-		parseSelectorToMarkedString(p, 'li.red.level', 'li', [{ language: 'html', value: '<li class="red level">' }, { language: 'text', value: 'Specificity: (0, 2, 1)' }]);
+		parseSelectorToMarkedString(p, 'ul ol li.red', 'ul', [
+			{ language: 'html', value: '<ul>\n  …\n    <ol>\n      …\n        <li class="red">' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 3)'
+		]);
+		parseSelectorToMarkedString(p, 'li.red.level', 'li', [
+			{ language: 'html', value: '<li class="red level">' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 2, 1)'
+		]);
 	});
 
 	test('pseudo class selector', function() {
-		parseSelectorToMarkedString(p, 'p:focus', 'p', [{ language: 'html', value: '<p :focus>' }, { language: 'text', value: 'Specificity: (0, 1, 1)' }]);
+		parseSelectorToMarkedString(p, 'p:focus', 'p', [
+			{ language: 'html', value: '<p :focus>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+		]);
 	});
-	
+
 	test('element selector', function() {
-		parseSelectorToMarkedString(p, 'li', 'li', [{ language: 'html', value: '<li>' }, { language: 'text', value: 'Specificity: (0, 0, 1)' }]);
-		parseSelectorToMarkedString(p, 'ul li', 'ul', [{ language: 'html', value: '<ul>\n  …\n    <li>' }, { language: 'text', value: 'Specificity: (0, 0, 2)' }]);
-		parseSelectorToMarkedString(p, 'ul ol+li', 'ul', [{ language: 'html', value: '<ul>\n  …\n    <ol>\n    <li>' }, { language: 'text', value: 'Specificity: (0, 0, 3)' }]);
+		parseSelectorToMarkedString(p, 'li', 'li', [
+			{ language: 'html', value: '<li>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+		]);
+		parseSelectorToMarkedString(p, 'ul li', 'ul', [
+			{ language: 'html', value: '<ul>\n  …\n    <li>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
+		parseSelectorToMarkedString(p, 'ul ol+li', 'ul', [
+			{ language: 'html', value: '<ul>\n  …\n    <ol>\n    <li>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 3)'
+		]);
 	});
 
 	test('pseudo element selector', function() {
-		parseSelectorToMarkedString(p, 'p::after', 'p', [{ language: 'html', value: '<p ::after>' }, { language: 'text', value: 'Specificity: (0, 0, 2)' }]);
+		parseSelectorToMarkedString(p, 'p::after', 'p', [
+			{ language: 'html', value: '<p ::after>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+		]);
 	});
-	
+
 	test('identifier selector', function() {
-		parseSelectorToMarkedString(p, '#x34y', '#x34y', [{ language: 'html', value: '<element id="x34y">' }, { language: 'text', value: 'Specificity: (1, 0, 0)' }]);
+		parseSelectorToMarkedString(p, '#x34y', '#x34y', [
+			{ language: 'html', value: '<element id="x34y">' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+		]);
 	});
-	
+
 	test('ignore universal and not selector', function() {
-		parseSelectorToMarkedString(p, '*', '*', [{ language: 'html', value: '<element>' }, { language: 'text', value: 'Specificity: (0, 0, 0)' }]);
-		parseSelectorToMarkedString(p, '#s12:not(foo)', '#s12', [{ language: 'html', value: '<element id="s12" :not>' }, { language: 'text', value: 'Specificity: (1, 0, 1)' }]);
+		parseSelectorToMarkedString(p, '*', '*', [
+			{ language: 'html', value: '<element>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 0)'
+		]);
+		parseSelectorToMarkedString(p, '#s12:not(foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :not>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+		]);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/62155

I renamed it "Selector specificity" instead of "CSS specificity" because the user would already know they are editing a CSS file and "Selector specificity" seemed like a better description.

I wasn't sure if the link should be included in the `localize()` call or not. MDN has that page in other languages so maybe it should be localized to link to the appropriate language page? If this is not how it should be done I can change it.

This is my first VS Code related contribution. I hope that it is helpful.