### PR TITLE
Don't warn for unknown properties inside an :export block

### DIFF
--- a/src/test/css/lint.test.ts
+++ b/src/test/css/lint.test.ts
@@ -113,6 +113,7 @@ suite('CSS - Lint', () => {
 		assertRuleSet('selector { -moz-box-shadow: "rest is missing" }', Rules.UnknownVendorSpecificProperty, Rules.IncludeStandardPropertyWhenUsingVendorPrefix);
 		assertRuleSet('selector { box-shadow: none }'); // no error
 		assertRuleSet('selector { box-property: "rest is missing" }', Rules.UnknownProperty);
+		assertRuleSet(':export { prop: "some" }') // no error for properties inside :export
 		assertRuleSetWithSettings('selector { foo: "some"; bar: 0px }', [], new LintConfigurationSettings({ validProperties: ['foo', 'bar'] }));
 		assertRuleSetWithSettings('selector { foo: "some"; }', [], new LintConfigurationSettings({ validProperties: ['foo', null] }));
 		assertRuleSetWithSettings('selector { bar: "some"; }', [Rules.UnknownProperty], new LintConfigurationSettings({ validProperties: ['foo'] }));

--- a/src/test/scss/lint.test.ts
+++ b/src/test/scss/lint.test.ts
@@ -45,6 +45,7 @@ suite('SCSS - Lint', () => {
 		assertRuleSet('selector { box-shadow: none }'); // no error
 		assertRuleSet('selector { -moz-#{box}-shadow: none }'); // no error if theres an interpolation
 		assertRuleSet('selector { outer: { nested : blue }'); // no error for nested
+		assertRuleSet(':export { prop: "some" }') // no error for properties inside :export
 	});
 
 	test('vendor specific prefixes', function () {


### PR DESCRIPTION
Currently custom properties inside a CSS modules `:export` block are reported as unknown. The properties inside `:export` are not CSS properties - they are custom properties that are exported from the CSS/SCSS file to Javascript (e.g. variables).

This PR adds a simple check to see if the selector is `:export`, and skips the whole checking for unknown properties in that case.

Please enable `Diff settings > hide whitespace changes` from Github's UI when reviewing the PR.

fixes #103