### PR TITLE
Improve box model analysis

### DIFF
--- a/src/services/boxModel.ts
+++ b/src/services/boxModel.ts
@@ -1,0 +1,234 @@
+
+import * as nodes from '../parser/cssNodes';
+import { includes } from '../utils/arrays';
+
+export class Element {
+
+	public name: string;
+	public node: nodes.Declaration;
+
+	constructor(text: string, data: nodes.Declaration) {
+		this.name = text;
+		this.node = data;
+	}
+}
+
+interface SideState {
+	value: boolean;
+
+	properties: Element[];
+}
+
+interface BoxModel {
+	width?: Element;
+
+	height?: Element;
+
+	top: SideState;
+
+	right: SideState;
+
+	bottom: SideState;
+
+	left: SideState;
+}
+
+function setSide<K extends 'top' | 'right' | 'bottom' | 'left'>(
+	model: BoxModel,
+	side: K,
+	value: boolean,
+	property: Element
+): void {
+	const state = model[side];
+
+	state.value = value;
+
+	if (value) {
+		if (!includes(state.properties, property)) {
+			state.properties.push(property);
+		}
+	}
+}
+
+function setAllSides(model: BoxModel, value: boolean, property: Element): void {
+	setSide(model, 'top', value, property);
+	setSide(model, 'right', value, property);
+	setSide(model, 'bottom', value, property);
+	setSide(model, 'left', value, property);
+}
+
+function updateModelWithValue(
+	model: BoxModel,
+	side: string,
+	value: boolean,
+	property: Element
+): void {
+	if (side === 'top' || side === 'right' ||
+		side === 'bottom' || side === 'left') {
+		setSide(model, side, value, property);
+	} else {
+		setAllSides(model, value, property);
+	}
+}
+
+function updateModelWithList(model: BoxModel, values: boolean[], property: Element): void {
+	switch (values.length) {
+		case 1:
+			updateModelWithValue(model, undefined, values[0], property);
+			break;
+		case 2:
+			updateModelWithValue(model, 'top', values[0], property);
+			updateModelWithValue(model, 'bottom', values[0], property);
+			updateModelWithValue(model, 'right', values[1], property);
+			updateModelWithValue(model, 'left', values[1], property);
+			break;
+		case 3:
+			updateModelWithValue(model, 'top', values[0], property);
+			updateModelWithValue(model, 'right', values[1], property);
+			updateModelWithValue(model, 'left', values[1], property);
+			updateModelWithValue(model, 'bottom', values[2], property);
+			break;
+		case 4:
+			updateModelWithValue(model, 'top', values[0], property);
+			updateModelWithValue(model, 'right', values[1], property);
+			updateModelWithValue(model, 'bottom', values[2], property);
+			updateModelWithValue(model, 'left', values[3], property);
+			break;
+	}
+}
+
+/**
+ * @param allowsKeywords whether the initial value of property is zero, so keywords `initial` and `unset` count as zero
+ * @return `true` if this node represents a non-zero border; otherwise, `false`
+ */
+function checkLineWidth(value: string, allowsKeywords: boolean = true): boolean {
+	if (allowsKeywords && includes(['initial', 'unset'], value)) {
+		return false;
+	}
+
+	// a <length> is a value and a unit
+	// so use `parseFloat` to strip the unit
+	return parseFloat(value) !== 0;
+}
+
+function checkLineWidthList(nodes: nodes.Node[], allowsKeywords: boolean = true): boolean[] {
+	return nodes.map(node => checkLineWidth(node.getText(), allowsKeywords));
+}
+
+/**
+ * @param allowsKeywords whether keywords `initial` and `unset` count as zero
+ * @return `true` if this node represents a non-zero border; otherwise, `false`
+ */
+function checkLineStyle(value: string, allowsKeywords: boolean = true): boolean {
+	if (includes(['none', 'hidden'], value)) {
+		return false;
+	}
+
+	if (allowsKeywords && includes(['initial', 'unset'], value)) {
+		return false;
+	}
+
+	return true;
+}
+
+function checkLineStyleList(nodes: nodes.Node[], allowsKeywords: boolean = true): boolean[] {
+	return nodes.map(node => checkLineStyle(node.getText(), allowsKeywords));
+}
+
+function checkBorderShorthand(node: nodes.Node): boolean {
+	const children = node.getChildren();
+
+	// the only child can be a keyword, a <line-width>, or a <line-style>
+	// if either check returns false, the result is no border
+	if (children.length === 1) {
+		const value = children[0].getText();
+		return checkLineWidth(value) && checkLineStyle(value);
+	}
+
+	// multiple children can't contain keywords
+	// if any child means no border, the result is no border
+	for (const child of children) {
+		const value = child.getText();
+		if (!checkLineWidth(value) || !checkLineStyle(value, /* allowsKeywords: */ false)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export default function calaculateBoxModel(propertyTable: Element[]): BoxModel {
+	let model: BoxModel = {
+		top: { value: false, properties: [] },
+		right: { value: false, properties: [] },
+		bottom: { value: false, properties: [] },
+		left: { value: false, properties: [] },
+	};
+
+	for (const property of propertyTable) {
+		const value = property.node.value;
+
+		switch (property.name) {
+			case 'box-sizing':
+				// has `box-sizing`, bail out
+				return {
+					top: { value: false, properties: [] },
+					right: { value: false, properties: [] },
+					bottom: { value: false, properties: [] },
+					left: { value: false, properties: [] },
+				};
+			case 'width':
+				model.width = property;
+				break;
+			case 'height':
+				model.height = property;
+				break;
+			default:
+				const segments = property.name.split('-');
+				switch (segments[0]) {
+					case 'border':
+						switch (segments[1]) {
+							case undefined:
+							case 'top':
+							case 'right':
+							case 'bottom':
+							case 'left':
+								switch (segments[2]) {
+									case undefined:
+										updateModelWithValue(model, segments[1], checkBorderShorthand(value), property);
+										break;
+									case 'width':
+										// the initial value of `border-width` is `medium`, not zero
+										updateModelWithValue(model, segments[1], checkLineWidth(value.getText(), false), property);
+										break;
+									case 'style':
+										// the initial value of `border-style` is `none`
+										updateModelWithValue(model, segments[1], checkLineStyle(value.getText(), true), property);
+										break;
+								}
+								break;
+							case 'width':
+								// the initial value of `border-width` is `medium`, not zero
+								updateModelWithList(model, checkLineWidthList(value.getChildren(), false), property);
+								break;
+							case 'style':
+								// the initial value of `border-style` is `none`
+								updateModelWithList(model, checkLineStyleList(value.getChildren(), true), property);
+								break;
+						}
+						break;
+					case 'padding':
+						if (segments.length === 1) {
+							// the initial value of `padding` is zero
+							updateModelWithList(model, checkLineWidthList(value.getChildren(), true), property);
+						} else {
+							// the initial value of `padding` is zero
+							updateModelWithValue(model, segments[1], checkLineWidth(value.getText(), true), property);
+						}
+						break;
+				}
+				break;
+		}
+	}
+
+	return model;
+}

--- a/src/services/boxModel.ts
+++ b/src/services/boxModel.ts
@@ -156,7 +156,7 @@ function checkBorderShorthand(node: nodes.Node): boolean {
 	return true;
 }
 
-export default function calaculateBoxModel(propertyTable: Element[]): BoxModel {
+export default function calculateBoxModel(propertyTable: Element[]): BoxModel {
 	let model: BoxModel = {
 		top: { value: false, properties: [] },
 		right: { value: false, properties: [] },

--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -7,7 +7,7 @@
 import * as languageFacts from './languageFacts';
 import { Rules, LintConfigurationSettings, Rule, Settings } from './lintRules';
 import * as nodes from '../parser/cssNodes';
-import calaculateBoxModel, { Element } from './boxModel';
+import calculateBoxModel, { Element } from './boxModel';
 import { union } from '../utils/arrays';
 
 import * as nls from 'vscode-nls';
@@ -280,7 +280,7 @@ export class LintVisitor implements nodes.IVisitor {
 		// No error when box-sizing property is specified, as it assumes the user knows what he's doing.
 		// see https://github.com/CSSLint/csslint/wiki/Beware-of-box-model-size
 		/////////////////////////////////////////////////////////////
-		const boxModel = calaculateBoxModel(propertyTable);
+		const boxModel = calculateBoxModel(propertyTable);
 		if (boxModel.width) {
 			let properties: Element[] = [];
 			if (boxModel.right.value) {

--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -7,7 +7,7 @@
 import * as languageFacts from './languageFacts';
 import { Rules, LintConfigurationSettings, Rule, Settings } from './lintRules';
 import * as nodes from '../parser/cssNodes';
-import calculateBoxModel, { Element } from './boxModel';
+import calculateBoxModel, { Element } from './lintUtil';
 import { union } from '../utils/arrays';
 
 import * as nls from 'vscode-nls';

--- a/src/services/lintUtil.ts
+++ b/src/services/lintUtil.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
 
 import * as nodes from '../parser/cssNodes';
 import { includes } from '../utils/arrays';

--- a/src/test/css/lint.test.ts
+++ b/src/test/css/lint.test.ts
@@ -119,11 +119,101 @@ suite('CSS - Lint', () => {
 	});
 
 	test('box model', function () {
-		assertRuleSet('.mybox { border: 1px solid black; width: 100px; }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
-		assertRuleSet('.mybox { height: 100px; padding: 10px; }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
-		assertRuleSet('.mybox { box-sizing: border-box; border: 1px solid black; width: 100px; }'); // no error
-		assertRuleSet('.mybox { border-top: 1px solid black; width: 100px; }'); // no error
-		assertRuleSet('.mybox { border-top: none; height: 100px; }'); // no error		
+		// border shorthand, zero values
+		assertRuleSet('.mybox { height: 100px;         border: initial;           }');
+		assertRuleSet('.mybox { height: 100px;         border: unset;             }');
+		assertRuleSet('.mybox { height: 100px;         border: none;              }');
+		assertRuleSet('.mybox { height: 100px;         border: hidden;            }');
+		assertRuleSet('.mybox { height: 100px;         border: 0;                 }');
+		assertRuleSet('.mybox { height: 100px;         border: 0 solid;           }');
+		assertRuleSet('.mybox { height: 100px;         border: 1px none;          }');
+		assertRuleSet('.mybox { height: 100px;         border: 0 solid #ccc;      }');
+		// order doesn't matter
+		assertRuleSet('.mybox { border: initial;       height: 100px;             }');
+		assertRuleSet('.mybox { border: 0;             height: 100px;             }');
+
+		// border shorthand, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border: 1px;               }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { height: 100px;         border: 1px solid;         }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { width: 100px;          border: 1px;               }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		// order doesn't matter
+		assertRuleSet('.mybox { border: 1px;           height: 100px;             }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { border: 1px solid;     height: 100px;             }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// border-top shorthand, zero values
+		assertRuleSet('.mybox { height: 100px;         border-top: initial;       }');
+		assertRuleSet('.mybox { height: 100px;         border-top: none;          }');
+		assertRuleSet('.mybox { height: 100px;         border-top: 0;             }');
+		assertRuleSet('.mybox { height: 100px;         border-top: 0 solid;       }');
+		assertRuleSet('.mybox { width: 100px;          border-top: 1px;           }');
+		assertRuleSet('.mybox { width: 100px;          border-top: 1px solid;     }');
+
+		// border-top shorthand, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border-top: 1px;           }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize); // shorthand | single value | 1px
+		assertRuleSet('.mybox { height: 100px;         border-top: 1px solid;     }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize); // shorthand |
+
+		// border-width shorthand, zero values
+		assertRuleSet('.mybox { height: 100px;         border-width: 0;           }');
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 0;         }');
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 0 0;       }');
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 0 0 0;     }');
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 1px;       }');
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 1px 0 1px; }');
+		assertRuleSet('.mybox { width: 100px;          border-width: 1px 0;       }');
+		assertRuleSet('.mybox { width: 100px;          border-width: 1px 0 1px 0; }');
+
+		// border-width shorthand, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border-width: 1px;         }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { height: 100px;         border-width: 0 0 1px;     }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { width: 100px;          border-width: 0 1px;       }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { width: 100px;          border-width: 0 0 0 1px;   }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// border-style shorthand, zero values
+		assertRuleSet('.mybox { height: 100px;         border-style: unset;       }');
+		assertRuleSet('.mybox { height: 100px;         border-style: initial;     }');
+		assertRuleSet('.mybox { height: 100px;         border-style: none;        }');
+		assertRuleSet('.mybox { height: 100px;         border-style: hidden;      }');
+
+		// border-style shorthand, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border-style: solid;       }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { height: 100px;         border-style: dashed;      }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// border-top-width property, zero values
+		assertRuleSet('.mybox { height: 100px;         border-top-width: 0;       }');
+		assertRuleSet('.mybox { width: 100px;          border-top-width: 1px;     }');
+
+		// border-top-width property, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border-top-width: 1px;     }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// border-top-style property, zero values
+		assertRuleSet('.mybox { height: 100px;         border-top-style: unset;   }');
+		assertRuleSet('.mybox { width: 100px;          border-top-style: solid;   }');
+
+		// border-top-style property, non-zero values
+		assertRuleSet('.mybox { height: 100px;         border-top-style: solid;   }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// padding shorthand, zero values
+		assertRuleSet('.mybox { height: 100px;         padding: initial;          }');
+		assertRuleSet('.mybox { height: 100px;         padding: unset;            }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0;                }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0 0;              }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0 0 0;            }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0 0 0 0;          }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0 1px;            }');
+		assertRuleSet('.mybox { height: 100px;         padding: 0 1px 0 1px;      }');
+		assertRuleSet('.mybox { width: 100px;          padding: 1px 0;            }');
+		assertRuleSet('.mybox { width: 100px;          padding: 1px 0 1px;        }');
+
+		// padding shorthand, non-zero values
+		assertRuleSet('.mybox { height: 100px;         padding: 1px;              }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { height: 100px;         padding: 1px 0;            }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+		assertRuleSet('.mybox { height: 100px;         padding: 0 0 1px;          }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
+
+		// box-sizing supress errors
+		assertRuleSet('.mybox { height: 100px;         border: 1px;               box-sizing: border-box; }');
+
+		// property be overriden
+		assertRuleSet('.mybox { height: 100px;         border: 1px;               border-top: 0; border-bottom: 0; }');
 	});
 
 	test('IE hacks', function () {

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -24,3 +24,19 @@ export function findFirst<T>(array: T[], p: (x: T) => boolean): number {
 	}
 	return low;
 }
+
+export function includes<T>(array: T[], item: T): boolean {
+	return array.indexOf(item) !== -1;
+}
+
+export function union<T>(...arrays: T[][]): T[] {
+	const result: T[] = [];
+	for (const array of arrays) {
+		for (const item of array) {
+			if (!includes(result, item)) {
+				result.push(item);
+			}
+		}
+	}
+	return result;
+}


### PR DESCRIPTION
I always have `css.lint.boxModel` on, but what I usually want to do is to override properties from other css files.

``` css
.element {
    width: 60px;
    padding: 0 !important;
}
```

The problem is, VS Code keeps warning me about this: **Do not use width or height when using padding or border.**

Does `padding: 0` really counts as *using*?

So instead of turn this feature off, I'd love to make it be aware of what I'm doing.