### PR TITLE
fix: handle incomplete rules in box model analysis

### DIFF
--- a/src/services/lintUtil.ts
+++ b/src/services/lintUtil.ts
@@ -154,7 +154,8 @@ function checkBorderShorthand(node: nodes.Node): boolean {
 	// if any child means no border, the result is no border
 	for (const child of children) {
 		const value = child.getText();
-		if (!checkLineWidth(value) || !checkLineStyle(value, /* allowsKeywords: */ false)) {
+		if (!checkLineWidth(value, /* allowsKeywords: */ false) ||
+			!checkLineStyle(value, /* allowsKeywords: */ false)) {
 			return false;
 		}
 	}
@@ -171,6 +172,9 @@ export default function calculateBoxModel(propertyTable: Element[]): BoxModel {
 
 	for (const property of propertyTable) {
 		const value = property.node.value;
+		if (typeof value === 'undefined') {
+			continue;
+		}
 
 		switch (property.name) {
 			case 'box-sizing':

--- a/src/test/css/lint.test.ts
+++ b/src/test/css/lint.test.ts
@@ -113,7 +113,7 @@ suite('CSS - Lint', () => {
 		assertRuleSet('selector { -moz-box-shadow: "rest is missing" }', Rules.UnknownVendorSpecificProperty, Rules.IncludeStandardPropertyWhenUsingVendorPrefix);
 		assertRuleSet('selector { box-shadow: none }'); // no error
 		assertRuleSet('selector { box-property: "rest is missing" }', Rules.UnknownProperty);
-		assertRuleSet(':export { prop: "some" }') // no error for properties inside :export
+		assertRuleSet(':export { prop: "some" }'); // no error for properties inside :export
 		assertRuleSetWithSettings('selector { foo: "some"; bar: 0px }', [], new LintConfigurationSettings({ validProperties: ['foo', 'bar'] }));
 		assertRuleSetWithSettings('selector { foo: "some"; }', [], new LintConfigurationSettings({ validProperties: ['foo', null] }));
 		assertRuleSetWithSettings('selector { bar: "some"; }', [Rules.UnknownProperty], new LintConfigurationSettings({ validProperties: ['foo'] }));
@@ -215,6 +215,11 @@ suite('CSS - Lint', () => {
 
 		// property be overriden
 		assertRuleSet('.mybox { height: 100px;         border: 1px;               border-top: 0; border-bottom: 0; }');
+
+		// imcomplete rules
+		assertRuleSet('.mybox { padding:; }');
+		assertRuleSet('.mybox { border: ');
+		assertRuleSet('.mybox { height: 100px;         padding: 1px;              border: }', Rules.BewareOfBoxModelSize, Rules.BewareOfBoxModelSize);
 	});
 
 	test('IE hacks', function () {

--- a/src/test/scss/lint.test.ts
+++ b/src/test/scss/lint.test.ts
@@ -45,7 +45,7 @@ suite('SCSS - Lint', () => {
 		assertRuleSet('selector { box-shadow: none }'); // no error
 		assertRuleSet('selector { -moz-#{box}-shadow: none }'); // no error if theres an interpolation
 		assertRuleSet('selector { outer: { nested : blue }'); // no error for nested
-		assertRuleSet(':export { prop: "some" }') // no error for properties inside :export
+		assertRuleSet(':export { prop: "some" }'); // no error for properties inside :export
 	});
 
 	test('vendor specific prefixes', function () {


### PR DESCRIPTION
I did't consider rules without values before.

fix Microsoft/vscode#66519