### PR TITLE
Improve scss partial uri building

### DIFF
--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -280,8 +280,8 @@ function uriStringNodeToDocumentLink(document: TextDocument, uriStringNode: node
 }
 
 function toScssPartialUri(uri: string): string {
-	return uri.replace(/\/(\w+)(.scss)?$/gm, (match, fileName) => {
-		return '/_' + fileName + '.scss';
+	return uri.replace(/\.scss$/, '').replace(/[^/]+$/, (basename) => {
+		return (basename[0] === '_' ? '': '_') + basename + '.scss';
 	});
 }
 

--- a/src/test/scss/scssNavigation.test.ts
+++ b/src/test/scss/scssNavigation.test.ts
@@ -85,16 +85,56 @@ suite('SCSS - Navigation', () => {
 				{ range: newRange(8, 15), target: 'test://test/_foo.scss' }
 			], 'scss');
 
+			assertLinks(p, `@import './_foo'`, [
+				{ range: newRange(8, 16), target: 'test://test/_foo.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './foo-baz'`, [
+				{ range: newRange(8, 19), target: 'test://test/_foo-baz.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './foo-baz.quz'`, [
+				{ range: newRange(8, 23), target: 'test://test/_foo-baz.quz.scss' }
+			], 'scss');
+
 			assertLinks(p, `@import './bar/foo'`, [
 				{ range: newRange(8, 19), target: 'test://test/bar/_foo.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './bar/_foo'`, [
+				{ range: newRange(8, 20), target: 'test://test/bar/_foo.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './bar/foo-baz.quz'`, [
+				{ range: newRange(8, 27), target: 'test://test/bar/_foo-baz.quz.scss' }
 			], 'scss');
 
 			assertLinks(p, `@import 'foo.scss'`, [
 				{ range: newRange(8, 18), target: 'test://test/_foo.scss' }
 			], 'scss');
 
+			assertLinks(p, `@import 'foo-baz.scss'`, [
+				{ range: newRange(8, 22), target: 'test://test/_foo-baz.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './foo-baz.quz.scss'`, [
+				{ range: newRange(8, 28), target: 'test://test/_foo-baz.quz.scss' }
+			], 'scss');
+
 			assertLinks(p, `@import './bar/foo.scss'`, [
 				{ range: newRange(8, 24), target: 'test://test/bar/_foo.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './bar/_foo.scss'`, [
+				{ range: newRange(8, 25), target: 'test://test/bar/_foo.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './bar/foo-baz.quz.scss'`, [
+				{ range: newRange(8, 32), target: 'test://test/bar/_foo-baz.quz.scss' }
+			], 'scss');
+
+			assertLinks(p, `@import './bar/_foo-baz.quz.scss'`, [
+				{ range: newRange(8, 33), target: 'test://test/bar/_foo-baz.quz.scss' }
 			], 'scss');
 		});
 


### PR DESCRIPTION
Currently the regex for checking filenames uses `\w` which only checks for alphanumeric characters and underscore (_). This leads to `@import './foobar'` resolving to `_foobar.scss` while `@import './foo-bar` resolves to `foo-bar`, which is confusing.

This PR makes the prefixing the underscore behaviour more consistent:

- Identifies filenames that contain non-alphanumeric characters,
  'foo-baz' becomes '_foo-baz.scss' and 'foo.bar' becomes '_foo.bar.scss'
- Identifies if a filename is already prefixed with an _, '_foo' becomes
  '_foo.scss' and '_foo.scss' remains '_foo.scss'



Tangentially related: https://github.com/microsoft/vscode/issues/58204 is an issue that points out that the resolution of scss files isn't trivial because `import './foo'` could refer to either `foo.scss` or `_foo.scss` and we need filesystem access to check which of those files exist. So we're still assuming that people should be prefixing their partial's filenames with underscores, but at least this makes that assumption a little more consistent.