### PR TITLE
Wrap URI.parse() call in try ... catch

### DIFF
--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -41,7 +41,15 @@ export class SCSSNavigation extends CSSNavigation {
 					continue;
 				}
 
-				const parsedUri = URI.parse(target);
+				let parsedUri = null;
+				try {
+					parsedUri = URI.parse(target);
+				} catch (e) {
+					if (e instanceof URIError) {
+						continue;
+					}
+					throw e;
+				}
 
 				const pathVariations = toPathVariations(parsedUri);
 				if (!pathVariations) {


### PR DESCRIPTION
When `URI.parse()` encounters an invalid URL it can throw a `URIError`, but the error is never caught and it pops up in the user's face (issue #173). So this patch simply puts the parse call in a try ... catch statement.

I don't know if the URI library is supposed to throw an error in this case, it may be an issue with vscode-uri.

Steps to reproduce the error:

1. Create a file named test.scss
2. Paste:

```
.test {
    background: url('<%=invalid%>');
}
```

3. Open the file in VS Code and observe an error notification:

![error-popup](https://user-images.githubusercontent.com/4525736/66262085-84a93500-e7fb-11e9-9bd3-8b69694686bb.png)

If you are wondering why I would be using an invalid URL - it's not really invalid, the CSS file produced by the SCSS compiler in my project is included inline into a JSP page, and the `url()` actually contains a JSP echo tag inside (`<%=some expression%>`). This used to work in VS Code 1.36 and earlier, but started to throw an error in newer releases.