### PR TITLE
Add support for parsing @apply rules in SCSS

### DIFF
--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -77,7 +77,7 @@ export class SCSSParser extends cssParser.Parser {
 		if (this.prevToken) {
 			node.colonPosition = this.prevToken.offset;
 		}
-		
+
 		if (!node.setValue(this._parseExpr())) {
 			return this.finish(node, ParseError.VariableValueExpected, [], panic);
 		}
@@ -218,7 +218,8 @@ export class SCSSParser extends cssParser.Parser {
 				|| this._parseMixinContent() // @content
 				|| this._parseMixinDeclaration() // nested @mixin
 				|| this._parseRuleset(true) // @at-rule
-				|| this._parseSupports(true); // @supports
+				|| this._parseSupports(true) // @supports
+				|| this._parseAtApply(); // @apply
 		}
 		return this._parseVariableDeclaration() // variable declaration
 			|| this._tryParseRuleset(true) // nested ruleset

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -334,6 +334,9 @@ suite('SCSS - Parser', () => {
 		assertNode('selector { property: value; property: $value; }', parser, parser._parseRuleset.bind(parser));
 		assertNode('selector { property: value; @keyframes foo {} @-moz-keyframes foo {}}', parser, parser._parseRuleset.bind(parser));
 		assertNode('foo|bar { }', parser, parser._parseRuleset.bind(parser));
+		assertNode('boo { @apply --custom-prop; }', parser, parser._parseRuleset.bind(parser));
+		assertNode('boo { @apply --custom-prop }', parser, parser._parseRuleset.bind(parser));
+		assertNode('boo { @apply --custom-prop; background-color: red }', parser, parser._parseRuleset.bind(parser));
 	});
 
 	test('Nested Ruleset', function () {


### PR DESCRIPTION
Related with #8 into SCSS files. This remove the error of use `@apply` inside SCSS.