### PR TITLE
Ability to use suggest participants for SCSS/Less mixins

### DIFF
--- a/src/cssLanguageTypes.ts
+++ b/src/cssLanguageTypes.ts
@@ -45,11 +45,17 @@ export interface ImportPathCompletionContext {
 	range: Range;
 }
 
+export interface MixinReferenceCompletionContext {
+	mixinName: string;
+	range: Range;
+}
+
 export interface ICompletionParticipant {
 	onCssProperty?: (context: PropertyCompletionContext) => void;
 	onCssPropertyValue?: (context: PropertyValueCompletionContext) => void;
 	onCssURILiteralValue?: (context: URILiteralCompletionContext) => void;
 	onCssImportPath?: (context: ImportPathCompletionContext) => void;
+	onCssMixinReference?: (context: MixinReferenceCompletionContext) => void;
 }
 
 export interface DocumentContext {

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -878,6 +878,18 @@ export class CSSCompletion {
 				result.items.push(this.makeTermProposal(mixinSymbol, mixinSymbol.node.getParameters(), null));
 			}
 		}
+
+		const identifierNode: nodes.Node | null = ref.getIdentifier() || null;
+
+		this.completionParticipants.forEach(participant => {
+			if (participant.onCssMixinReference) {
+				participant.onCssMixinReference({
+					mixinName: this.currentWord,
+					range: this.getCompletionRange(identifierNode)
+				});
+			}
+		});
+
 		return result;
 	}
 


### PR DESCRIPTION
As a part of the revival of the [vscode-scss](https://github.com/mrmlnc/vscode-scss) plugin I want to use the completion participant mechanism how it is done in the built-in VSCode CSS extension ([click](https://github.com/microsoft/vscode/blob/93f58e063efcb86960ec1f2529186a63e655ee6c/extensions/css-language-features/server/src/cssServerMain.ts#L242)).

I found that for successful application of this mechanism I only lack references to mixins. So, just add it :)

My motivation:

* Use the same mechanism as the built-in solution to avoid the difference in experience.