### PR TITLE
Fix variables before use and forward

### DIFF
--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -22,7 +22,11 @@ export class SCSSParser extends cssParser.Parser {
 	}
 
 	public _parseStylesheetStart(): nodes.Node | null {
-		return this._parseForward()
+		if (this.peek(TokenType.SemiColon)) {
+			this.consumeToken();
+		}
+		return this._parseVariableDeclaration()
+			|| this._parseForward()
 			|| this._parseUse()
 			|| super._parseStylesheetStart();
 	}
@@ -853,7 +857,7 @@ export class SCSSParser extends cssParser.Parser {
 			// Consume all variables and idents ahead.
 		}
 
-		// More than just identifier 
+		// More than just identifier
 		return node.getChildren().length > 1 ? node : null;
 	}
 

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -296,6 +296,7 @@ suite('SCSS - Parser', () => {
 		assertError('@use "test" with ($foo: 1, "bar")', parser, parser._parseUse.bind(parser), ParseError.VariableNameExpected);
 		assertError('@use "test" with ($foo: "bar"', parser, parser._parseUse.bind(parser), ParseError.RightParenthesisExpected);
 
+		assertNode('$test: "test"; @use "lib"', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@forward "test"; @use "lib"', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@use "test"; @use "lib"', parser, parser._parseStylesheet.bind(parser));
 		assertError('body { @use "test" }', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);
@@ -322,6 +323,7 @@ suite('SCSS - Parser', () => {
 		assertError('@forward "test" show', parser, parser._parseForward.bind(parser), ParseError.IdentifierOrVariableExpected);
 		assertError('@forward "test" hide', parser, parser._parseForward.bind(parser), ParseError.IdentifierOrVariableExpected);
 
+		assertNode('$test: "test"; @forward "test"', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@use "lib"; @forward "test"', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@forward "test"; @forward "lib"', parser, parser._parseStylesheet.bind(parser));
 		assertError('body { @forward "test" }', parser, parser._parseStylesheet.bind(parser), ParseError.RightCurlyExpected);


### PR DESCRIPTION
This is a proposed fix for Issue #203 

It should work but I'm unsure about throwing the semicolon token part:

In essence it is required if we want to parse all @foward and @use rules because `_parseVariableDeclaration` doesn't throw it away itself (and some other part of the parser expect that behavior). I'm just throwing the semicolon without any further check because it isn't a problem if a file start with a semicolon in SCSS but let me know if we want to be a bit more conservative here.