### PR TITLE
Use node type to check for id selectors

### DIFF
--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import * as languageFacts from '../languageFacts/facts';
-import { Rules, LintConfigurationSettings, Rule, Settings } from './lintRules';
-import * as nodes from '../parser/cssNodes';
-import calculateBoxModel, { Element } from './lintUtil';
-import { union } from '../utils/arrays';
-
 import * as nls from 'vscode-nls';
 import { TextDocument } from '../cssLanguageTypes';
 import { CSSDataManager } from '../languageFacts/dataManager';
+import * as languageFacts from '../languageFacts/facts';
+import * as nodes from '../parser/cssNodes';
+import { union } from '../utils/arrays';
+import { LintConfigurationSettings, Rule, Rules, Settings } from './lintRules';
+import calculateBoxModel, { Element } from './lintUtil';
+
 
 const localize = nls.loadMessageBundle();
 
@@ -170,6 +170,8 @@ export class LintVisitor implements nodes.IVisitor {
 				return this.visitHexColorValue(<nodes.HexColorValue>node);
 			case nodes.NodeType.Prio:
 				return this.visitPrio(node);
+			case nodes.NodeType.IdentifierSelector:
+				return this.visitIdentifierSelector(node);
 		}
 		return true;
 	}
@@ -235,22 +237,23 @@ export class LintVisitor implements nodes.IVisitor {
 	}
 
 	private visitSimpleSelector(node: nodes.SimpleSelector): boolean {
-
-		const firstChar = this.documentText.charAt(node.offset);
-
 		/////////////////////////////////////////////////////////////
 		//	Lint - The universal selector (*) is known to be slow.
 		/////////////////////////////////////////////////////////////
+		const firstChar = this.documentText.charAt(node.offset);
+
 		if (node.length === 1 && firstChar === '*') {
 			this.addEntry(node, Rules.UniversalSelector);
 		}
 
+		return true;
+	}
+
+	private visitIdentifierSelector(node: nodes.Node): boolean {
 		/////////////////////////////////////////////////////////////
 		//	Lint - Avoid id selectors
 		/////////////////////////////////////////////////////////////
-		if (firstChar === '#') {
-			this.addEntry(node, Rules.AvoidIdSelector);
-		}
+		this.addEntry(node, Rules.AvoidIdSelector);
 		return true;
 	}
 

--- a/src/test/scss/lint.test.ts
+++ b/src/test/scss/lint.test.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import { TextDocument } from '../../cssLanguageTypes';
+import { SCSSParser } from '../../parser/scssParser';
 import { Rule, Rules } from '../../services/lintRules';
 import { assertEntries } from '../css/lint.test';
-import { SCSSParser } from '../../parser/scssParser';
-import { TextDocument } from '../../cssLanguageTypes';
 
 function assertFontFace(input: string, ...rules: Rule[]): void {
 	let p = new SCSSParser();
@@ -28,6 +28,18 @@ suite('SCSS - Lint', () => {
 
 	test('empty ruleset', function () {
 		assertRuleSet('selector { color: red; nested {} }', Rules.EmptyRuleSet);
+	});
+
+	test('ID selectors', function () {
+		assertRuleSet('#id { color: red; }', Rules.AvoidIdSelector);
+		assertRuleSet('element#id { color: red; }', Rules.AvoidIdSelector);
+		assertRuleSet('#id__#{foo} { color: red; }', Rules.AvoidIdSelector);
+	});
+
+	test('Interpolation selectors', function () {
+		assertRuleSet('#{foo} { color: red; }');
+		assertRuleSet('#{foo}__cont { color: red; }');
+		assertRuleSet('#{foo}.class { color: red; }');
 	});
 
 	test('font-face required properties', function () {


### PR DESCRIPTION
Following on from the discussion in https://github.com/microsoft/vscode/issues/75905#issuecomment-733606749.

This change replaces the check for a `#` character with a node type check when linting ID selectors. This is to avoid the "avoid id selectors" rule from highlighting interpolations in scss.

This also fixes a bug that the ID lint would only warn when the ID was the first selector in the rule, eg. it would detect `#foo.bar` but not `.bar#foo`.

I've added a couple more tests to cover some different id selectors and interpolations.

While this works, would it be better to add a condition on [this switch](https://github.com/microsoft/vscode-css-languageservice/blob/982dc8849a81e0f77c12b57c34e2da5263b93f2e/src/services/lint.ts#L152) to find and handle `IdentifierSelectors` rather than the loop through the `SimpleSelector` children that I have in this PR?