### PR TITLE
handle newlines in JSON and implement fast object initialization

### DIFF
--- a/build/generateData.js
+++ b/build/generateData.js
@@ -10,7 +10,9 @@ const os = require('os')
 const customData = require('vscode-web-custom-data/data/browsers.css-data.json');
 
 function toJavaScript(obj) {
-	return JSON.stringify(obj, null, '\t');
+	return JSON.stringify(obj, null, '\t').replace(/\u2028|\u2029/g, str =>
+		str === "\u2029" ? "\\u2029" : "\\u2028"
+	); // invalid in JavaScript source but valid JSON
 }
 
 const DATA_TYPE = 'CSSDataV1';
@@ -23,7 +25,7 @@ const output = [
 	'',
 	`import { ${DATA_TYPE} } from '../cssLanguageTypes';`,
 	'',
-	`export const cssData : ${DATA_TYPE} = ` + toJavaScript(customData) + ';'
+	`export const htmlData = JSON.parse('${toJavaScript(customData).replace(/[\\']/g, "\\$&")}') as ${DATA_TYPE};`
 ];
 
 var outputPath = path.resolve(__dirname, '../src/data/webCustomData.ts');


### PR DESCRIPTION
I haven't tested these changes. Here's where I'm basing this change off of: https://github.com/webpack/webpack/pull/12642.

- [newlines in javascript string literals from JSON stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#issue_with_plain_json.stringify_for_use_as_javascript)
- [fast large object initialization](https://www.bram.us/2019/11/25/faster-javascript-apps-with-json-parse/)