### PR TITLE
Respect `kind` property

### DIFF
--- a/src/languageFacts/entry.ts
+++ b/src/languageFacts/entry.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { EntryStatus, IPropertyData, IAtDirectiveData, IPseudoClassData, IPseudoElementData, IValueData, MarkupContent, MarkedString, HoverSettings } from '../cssLanguageTypes';
+import { EntryStatus, IPropertyData, IAtDirectiveData, IPseudoClassData, IPseudoElementData, IValueData, MarkupContent, MarkupKind, MarkedString, HoverSettings } from '../cssLanguageTypes';
 
 export interface Browsers {
 	E?: string;
@@ -114,10 +114,12 @@ function getEntryMarkdownDescription(entry: IEntry2, settings?: HoverSettings): 
 		if (entry.status) {
 			result += getEntryStatus(entry.status);
 		}
-
-		const description = typeof entry.description === 'string' ? entry.description : entry.description.value;
-
-		result += textToMarkedString(description);
+	
+		if (typeof entry.description === 'string') {
+			result += textToMarkedString(description);
+		} else {
+			result += entry.type === MarkupKind.Markdown ? entry.description.value : textToMarkedString(entry.description.value);
+		}
 
 		const browserLabel = getBrowserLabel(entry.browsers);
 		if (browserLabel) {

--- a/src/languageFacts/entry.ts
+++ b/src/languageFacts/entry.ts
@@ -116,7 +116,7 @@ function getEntryMarkdownDescription(entry: IEntry2, settings?: HoverSettings): 
 		}
 	
 		if (typeof entry.description === 'string') {
-			result += textToMarkedString(description);
+			result += textToMarkedString(entry.description);
 		} else {
 			result += entry.type === MarkupKind.Markdown ? entry.description.value : textToMarkedString(entry.description.value);
 		}


### PR DESCRIPTION
The current code escapes the markdown regardless of if the `kind` property is set to `markdown`. 

This PR updates it to skip escaping the string if it is supposed to be markdown.