### PR TITLE
Feat: support new resolving import at-rules

### DIFF
--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -106,7 +106,7 @@ export function getCSSLanguageService(options: LanguageServiceOptions = defaultL
 		new Parser(),
 		new CSSCompletion(null, options, cssDataManager),
 		new CSSHover(options && options.clientCapabilities, cssDataManager),
-		new CSSNavigation(options && options.fileSystemProvider),
+		new CSSNavigation(options && options.fileSystemProvider, false),
 		new CSSCodeActions(cssDataManager),
 		new CSSValidation(cssDataManager),
 		cssDataManager
@@ -132,7 +132,7 @@ export function getLESSLanguageService(options: LanguageServiceOptions = default
 		new LESSParser(),
 		new LESSCompletion(options, cssDataManager),
 		new CSSHover(options && options.clientCapabilities, cssDataManager),
-		new CSSNavigation(options && options.fileSystemProvider),
+		new CSSNavigation(options && options.fileSystemProvider, true),
 		new CSSCodeActions(cssDataManager),
 		new CSSValidation(cssDataManager),
 		cssDataManager

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -303,7 +303,7 @@ export class CSSNavigation {
 				return joinPath(modulePath, pathWithinModule);
 			}
 		}
-		return documentContext.resolveReference(ref, documentUri);
+		return undefined;
 	}
 
 	protected async resolveRelativeReference(ref: string, documentUri: string, documentContext: DocumentContext, isRawLink?: boolean): Promise<string | undefined> {
@@ -322,7 +322,7 @@ export class CSSNavigation {
 		if (relativeReference) {
 			return relativeReference;
 		} else {
-			return await this.resolveModuleReference(ref, documentUri, documentContext)
+			return await this.resolveModuleReference(ref, documentUri, documentContext);
 		}
 	}
 

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -297,7 +297,7 @@ export class CSSNavigation {
 		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
 		// convention, if an import path starts with ~ or a package name then use node module resolution
 		// *unless* it starts with "~/" as this refers to the user's home directory.
-		if (/[a-zA-Z0-9~]/.test(ref[0]) && ref[1] !== '/' && this.fileSystemProvider) {
+		if (/[a-zA-Z0-9_~]/.test(ref[0]) && ref[1] !== '/' && this.fileSystemProvider) {
 			ref = ref.substring(1);
 			if (startsWith(documentUri, 'file://')) {
 				const moduleName = getModuleNameFromPath(ref);

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -308,6 +308,7 @@ export class CSSNavigation {
 
 	protected async resolveRelativeReference(ref: string, documentUri: string, documentContext: DocumentContext, isRawLink?: boolean): Promise<string | undefined> {
 		const relativeReference = documentContext.resolveReference(ref, documentUri);
+
 		// Following [css-loader](https://github.com/webpack-contrib/css-loader#url)
 		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
 		// convention, if an import path starts with ~ then use node module resolution
@@ -325,7 +326,7 @@ export class CSSNavigation {
 			if (relativeReference && await this.fileExists(relativeReference)) {
 				return relativeReference;
 			} else {
-				return await this.resolveModuleReference(ref, documentUri, documentContext);
+				return await this.resolveModuleReference(ref, documentUri, documentContext) || relativeReference;
 			}
 		}
 

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -24,7 +24,7 @@ const startsWithData = /^data:/;
 
 export class CSSNavigation {
 
-	constructor(protected fileSystemProvider: FileSystemProvider | undefined) {
+	constructor(protected fileSystemProvider: FileSystemProvider | undefined, private readonly resolveModuleReferences: boolean) {
 	}
 
 	public findDefinition(document: TextDocument, position: Position, stylesheet: nodes.Node): Location | null {
@@ -322,7 +322,7 @@ export class CSSNavigation {
 		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules)
 		// new resolving import at-rules (~ is deprecated). The loader will first try to resolve @import as a relative path. If it cannot be resolved, 
 		// then the loader will try to resolve @import inside node_modules.
-		if (documentUri.endsWith('.less') || documentUri.endsWith('.scss') || documentUri.endsWith('.sass')) {
+		if (this.resolveModuleReferences) {
 			if (relativeReference && await this.fileExists(relativeReference)) {
 				return relativeReference;
 			} else {

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -319,7 +319,7 @@ export class CSSNavigation {
 
 		// Using ~ is deprecated. The loader will first try to resolve @import as a relative path. If it cannot be resolved, 
 		// then the loader will try to resolve @import inside node_modules.
-		if (relativeReference) {
+		if (relativeReference && await this.fileExists(relativeReference)) {
 			return relativeReference;
 		} else {
 			return await this.resolveModuleReference(ref, documentUri, documentContext);

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -317,13 +317,19 @@ export class CSSNavigation {
 			return await this.resolveModuleReference(ref, documentUri, documentContext) || relativeReference;
 		}
 
-		// Using ~ is deprecated. The loader will first try to resolve @import as a relative path. If it cannot be resolved, 
+		// Following [less-loader](https://github.com/webpack-contrib/less-loader#imports)
+		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules)
+		// new resolving import at-rules (~ is deprecated). The loader will first try to resolve @import as a relative path. If it cannot be resolved, 
 		// then the loader will try to resolve @import inside node_modules.
-		if (relativeReference && await this.fileExists(relativeReference)) {
-			return relativeReference;
-		} else {
-			return await this.resolveModuleReference(ref, documentUri, documentContext);
+		if (documentUri.endsWith('.less') || documentUri.endsWith('.scss') || documentUri.endsWith('.sass')) {
+			if (relativeReference && await this.fileExists(relativeReference)) {
+				return relativeReference;
+			} else {
+				return await this.resolveModuleReference(ref, documentUri, documentContext);
+			}
 		}
+
+		return relativeReference;
 	}
 
 	private async resolvePathToModule(_moduleName: string, documentFolderUri: string, rootFolderUri: string | undefined): Promise<string | undefined> {

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -303,7 +303,7 @@ export class CSSNavigation {
 				return joinPath(modulePath, pathWithinModule);
 			}
 		}
-		return undefined;
+		return documentContext.resolveReference(ref, documentUri);
 	}
 
 	protected async resolveRelativeReference(ref: string, documentUri: string, documentContext: DocumentContext, isRawLink?: boolean): Promise<string | undefined> {

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -307,20 +307,20 @@ export class CSSNavigation {
 	}
 
 	protected async resolveRelativeReference(ref: string, documentUri: string, documentContext: DocumentContext, isRawLink?: boolean): Promise<string | undefined> {
-		const RelativeReference = documentContext.resolveReference(ref, documentUri);
+		const relativeReference = documentContext.resolveReference(ref, documentUri);
 		// Following [css-loader](https://github.com/webpack-contrib/css-loader#url)
 		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
 		// convention, if an import path starts with ~ then use node module resolution
 		// *unless* it starts with "~/" as this refers to the user's home directory.
 		if (ref[0] === '~' && ref[1] !== '/' && this.fileSystemProvider) {
 			ref = ref.substring(1);
-			return await this.resolveModuleReference(ref, documentUri, documentContext) || RelativeReference;
+			return await this.resolveModuleReference(ref, documentUri, documentContext) || relativeReference;
 		}
 
 		// Using ~ is deprecated. The loader will first try to resolve @import as a relative path. If it cannot be resolved, 
 		// then the loader will try to resolve @import inside node_modules.
-		if (RelativeReference) {
-			return RelativeReference;
+		if (relativeReference) {
+			return relativeReference;
 		} else {
 			return await this.resolveModuleReference(ref, documentUri, documentContext)
 		}

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -295,9 +295,9 @@ export class CSSNavigation {
 	protected async resolveRelativeReference(ref: string, documentUri: string, documentContext: DocumentContext, isRawLink?: boolean): Promise<string | undefined> {
 		// Following [css-loader](https://github.com/webpack-contrib/css-loader#url)
 		// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
-		// convention, if an import path starts with ~ then use node module resolution
+		// convention, if an import path starts with ~ or a package name then use node module resolution
 		// *unless* it starts with "~/" as this refers to the user's home directory.
-		if (ref[0] === '~' && ref[1] !== '/' && this.fileSystemProvider) {
+		if (/[a-zA-Z0-9~]/.test(ref[0]) && ref[1] !== '/' && this.fileSystemProvider) {
 			ref = ref.substring(1);
 			if (startsWith(documentUri, 'file://')) {
 				const moduleName = getModuleNameFromPath(ref);

--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -12,7 +12,7 @@ import { startsWith } from '../utils/strings';
 
 export class SCSSNavigation extends CSSNavigation {
 	constructor(fileSystemProvider: FileSystemProvider | undefined) {
-		super(fileSystemProvider);
+		super(fileSystemProvider, true);
 	}
 
 	protected isRawStringDocumentLinkNode(node: nodes.Node): boolean {

--- a/src/test/scss/scssNavigation.test.ts
+++ b/src/test/scss/scssNavigation.test.ts
@@ -218,7 +218,7 @@ suite('SCSS - Navigation', () => {
 			);
 
 			await assertLinks(ls, 'html { background-image: url("foo/hello.html")',
-				[{ range: newRange(28, 45), target: getTestResource('node_modules/foo/hello.html') }], 'scss', testUri, workspaceFolder
+				[{ range: newRange(29, 45), target: getTestResource('node_modules/foo/hello.html') }], 'scss', testUri, workspaceFolder
 			);
 		});
 


### PR DESCRIPTION
https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules

> Using `~` is deprecated and can be removed from your code (we recommend it), but we still support it for historical reasons. Why can you remove it? The loader will first try to resolve @import as a relative path. If it cannot be resolved, then the loader will try to resolve @import inside `node_modules`.

Support VS Code DefinitionProvider find right package like:

```scss
@import "bootstrap";
@import "~bootstrap";
```