### PR TITLE
css color : add support for hue rad|grad|turn

### DIFF
--- a/src/languageFacts/colors.ts
+++ b/src/languageFacts/colors.ts
@@ -196,11 +196,11 @@ function getAngle(node: nodes.Node) {
 			case 'deg':
 				return parseFloat(val) % 360;
 			case 'rad':
-				return parseFloat(val) * 180 / Math.PI;
+				return (parseFloat(val) * 180 / Math.PI) % 360;
 			case 'grad':
-				return parseFloat(val) * 0.9;
+				return (parseFloat(val) * 0.9) % 360;
 			case 'turn':
-				return parseFloat(val) * 360;
+				return (parseFloat(val) * 360) % 360;
 			default:
 				if ('undefined' === typeof m[2]) {
 					return parseFloat(val) % 360;

--- a/src/languageFacts/colors.ts
+++ b/src/languageFacts/colors.ts
@@ -190,10 +190,24 @@ function getNumericValue(node: nodes.Node, factor: number) {
 
 function getAngle(node: nodes.Node) {
 	const val = node.getText();
-	const m = val.match(/^([-+]?[0-9]*\.?[0-9]+)(deg)?$/);
+	const m = val.match(/^([-+]?[0-9]*\.?[0-9]+)(deg|rad|grad|turn)?$/);
 	if (m) {
-		return parseFloat(val) % 360;
+		switch (m[2]) {
+			case 'deg':
+				return parseFloat(val) % 360;
+			case 'rad':
+				return parseFloat(val) * 180 / Math.PI;
+			case 'grad':
+				return parseFloat(val) * 0.9;
+			case 'turn':
+				return parseFloat(val) * 360;
+			default:
+				if ('undefined' === typeof m[2]) {
+					return parseFloat(val) % 360;
+				}
+		}
 	}
+
 	throw new Error();
 }
 

--- a/src/test/css/languageFacts.test.ts
+++ b/src/test/css/languageFacts.test.ts
@@ -103,6 +103,12 @@ suite('CSS - Language Facts', () => {
 		assertColor(parser, '#main { color: hsl(180,100%,25%, 0.33) }', 'hsl', colorFrom256RGB(0, 0.5 * 255, 0.5 * 255, 0.33));
 		assertColor(parser, '#main { color: hsl(30,20%,30%, 0) }', 'hsl', colorFrom256RGB(92, 77, 61, 0));
 		assertColor(parser, '#main { color: hsla(38deg,89%,89%, 0) }', 'hsl', colorFrom256RGB(252, 234, 202, 0));
+		assertColor(parser, '#main { color: hsl(0.5turn, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
+		assertColor(parser, '#main { color: hsl(200grad, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
+		assertColor(parser, '#main { color: hsl(3.14159rad, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
+		assertColor(parser, '#main { color: hsl(0.13turn, 97%, 32%) }', 'hsl', colorFrom256RGB(161, 126, 2, 1));
+		assertColor(parser, '#main { color: hsl(124grad, 71%, 45%) }', 'hsl', colorFrom256RGB(56, 196, 33, 1));
+		assertColor(parser, '#main { color: hsl(2.35112rad, 76%, 63%) }', 'hsl', colorFrom256RGB(89, 232, 124, 1));
 		assertColor(parser, '#main { color: rgba(0.7) }', 'rgba', null, true);
 		assertColor(parser, '[green] {}', 'green', null);
 		assertColor(parser, '[data-color=green] {}', 'green', null);

--- a/src/test/css/languageFacts.test.ts
+++ b/src/test/css/languageFacts.test.ts
@@ -104,6 +104,7 @@ suite('CSS - Language Facts', () => {
 		assertColor(parser, '#main { color: hsl(30,20%,30%, 0) }', 'hsl', colorFrom256RGB(92, 77, 61, 0));
 		assertColor(parser, '#main { color: hsla(38deg,89%,89%, 0) }', 'hsl', colorFrom256RGB(252, 234, 202, 0));
 		assertColor(parser, '#main { color: hsl(0.5turn, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
+		assertColor(parser, '#main { color: hsl(1.5turn, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
 		assertColor(parser, '#main { color: hsl(200grad, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
 		assertColor(parser, '#main { color: hsl(3.14159rad, 100%, 50%) }', 'hsl', colorFrom256RGB(0, 255, 255, 1));
 		assertColor(parser, '#main { color: hsl(0.13turn, 97%, 32%) }', 'hsl', colorFrom256RGB(161, 126, 2, 1));


### PR DESCRIPTION
[spec](https://www.w3.org/TR/css-values-4/#angle-value)

> 7.1. Angle Units: the <angle> type and deg, grad, rad, turn units
> 
> Angle values are <dimension>s denoted by <angle>. The angle unit identifiers are:
> 
> deg
> Degrees. There are 360 degrees in a full circle.
>
> grad
> Gradians, also known as "gons" or "grades". There are 400 gradians in a full circle.
>
> rad
> Radians. There are 2π radians in a full circle.
>
> turn
> Turns. There is 1 turn in a full circle.

-------

Aiming to get the color indicator here :

```
color: hsl(0.5turn 100% 50%);
color: hsl(200grad 100% 50%);
color: hsl(3.14159rad 100% 50%);
```

<img width="284" alt="Screenshot 2021-12-23 at 10 45 19" src="https://user-images.githubusercontent.com/11521496/147221808-1797ce12-8999-4942-abd0-378705f3ce1e.png">

