### PR TITLE
fix specificity for :has, :not, :is and :where

### DIFF
--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -400,25 +400,34 @@ export class SelectorPrinting {
 						if (text.match(/^:(not|has|is)/i) && element.getChildren().length > 0) {
 							let mostSpecificListItem = new Specificity();
 
-							for (const element of node.getChildren()) {
-								const itemSpecificity = calculateScore(element);
-								if (itemSpecificity.id > mostSpecificListItem.id) {
-									mostSpecificListItem = itemSpecificity;
-									break;
-								} else if (itemSpecificity.id < mostSpecificListItem.id) {
-									break;
+							for (const containerElement of element.getChildren()) {
+								let list;
+								if (containerElement.type !== nodes.NodeType.Undefined) {
+									list = [containerElement];
+								} else {
+									list = containerElement.getChildren();
 								}
 
-								if (itemSpecificity.attr > mostSpecificListItem.attr) {
-									mostSpecificListItem = itemSpecificity;
-									break;
-								} else if (itemSpecificity.attr < mostSpecificListItem.attr) {
-									break;
-								}
+								for (const childElement of containerElement.getChildren()) {
+									const itemSpecificity = calculateScore(childElement);
+									if (itemSpecificity.id > mostSpecificListItem.id) {
+										mostSpecificListItem = itemSpecificity;
+										continue;
+									} else if (itemSpecificity.id < mostSpecificListItem.id) {
+										continue;
+									}
 
-								if (itemSpecificity.tag > mostSpecificListItem.tag) {
-									mostSpecificListItem = itemSpecificity;
-									break;
+									if (itemSpecificity.attr > mostSpecificListItem.attr) {
+										mostSpecificListItem = itemSpecificity;
+										continue;
+									} else if (itemSpecificity.attr < mostSpecificListItem.attr) {
+										continue;
+									}
+
+									if (itemSpecificity.tag > mostSpecificListItem.tag) {
+										mostSpecificListItem = itemSpecificity;
+										continue;
+									}
 								}
 							}
 

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -361,44 +361,89 @@ export class SelectorPrinting {
 
 	private selectorToSpecificityMarkedString(node: nodes.Node): MarkedString {
 		//https://www.w3.org/TR/selectors-3/#specificity
-		const calculateScore = (node: nodes.Node) => {
-			for (const element of node.getChildren()) {
+		const calculateScore = (node: nodes.Node): Specificity => {
+			const specificity = new Specificity();
+
+			elementLoop: for (const element of node.getChildren()) {
 				switch (element.type) {
 					case nodes.NodeType.IdentifierSelector:
 						specificity.id++;
 						break;
+
 					case nodes.NodeType.ClassSelector:
 					case nodes.NodeType.AttributeSelector:
 						specificity.attr++;
 						break;
+
 					case nodes.NodeType.ElementNameSelector:
 						//ignore universal selector
 						if (element.matches("*")) {
 							break;
 						}
+
 						specificity.tag++;
 						break;
+
 					case nodes.NodeType.PseudoSelector:
 						const text = element.getText();
 						if (this.isPseudoElementIdentifier(text)) {
 							specificity.tag++;	// pseudo element
-						} else {
-							//ignore psuedo class NOT
-							if (text.match(/^:not/i)) {
-								break;
-							}
-							specificity.attr++;	//pseudo class
+							break;
 						}
+
+						// where and child selectors have zero specificity
+						if (text.match(/^:where/i)) {
+							continue elementLoop;
+						}
+
+						// the most specific child selector
+						if (text.match(/^:(not|has|is)/i) && element.getChildren().length > 0) {
+							let mostSpecificListItem = new Specificity();
+
+							for (const element of node.getChildren()) {
+								const itemSpecificity = calculateScore(element);
+								if (itemSpecificity.id > mostSpecificListItem.id) {
+									mostSpecificListItem = itemSpecificity;
+									break;
+								} else if (itemSpecificity.id < mostSpecificListItem.id) {
+									break;
+								}
+
+								if (itemSpecificity.attr > mostSpecificListItem.attr) {
+									mostSpecificListItem = itemSpecificity;
+									break;
+								} else if (itemSpecificity.attr < mostSpecificListItem.attr) {
+									break;
+								}
+
+								if (itemSpecificity.tag > mostSpecificListItem.tag) {
+									mostSpecificListItem = itemSpecificity;
+									break;
+								}
+							}
+
+							specificity.id += mostSpecificListItem.id;
+							specificity.attr += mostSpecificListItem.attr;
+							specificity.tag += mostSpecificListItem.tag;
+							continue elementLoop;
+						}
+
+						specificity.attr++;	//pseudo class
 						break;
 				}
+
 				if (element.getChildren().length > 0) {
-					calculateScore(element);
+					const itemSpecificity = calculateScore(element);
+					specificity.id += itemSpecificity.id;
+					specificity.attr += itemSpecificity.attr;
+					specificity.tag += itemSpecificity.tag;
 				}
 			}
+
+			return specificity;
 		};
 
-		const specificity = new Specificity();
-		calculateScore(node);
+		const specificity = calculateScore(node);;
 		return localize('specificity', "[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): ({0}, {1}, {2})", specificity.id, specificity.attr, specificity.tag);
 	}
 

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -402,10 +402,10 @@ export class SelectorPrinting {
 
 							for (const containerElement of element.getChildren()) {
 								let list;
-								if (containerElement.type !== nodes.NodeType.Undefined) {
-									list = [containerElement];
-								} else {
+								if (containerElement.type === nodes.NodeType.Undefined) { // containerElement is a list of selectors
 									list = containerElement.getChildren();
+								} else { // containerElement is a selector
+									list = [containerElement];
 								}
 
 								for (const childElement of containerElement.getChildren()) {

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -245,4 +245,61 @@ suite('CSS - MarkedStringPrinter selectors specificities', () => {
 			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
 		]);
 	});
+
+	test('where specificity', function () {
+		assertSelectorMarkdown(p, '#s12:where(foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :where>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+		]);
+		assertSelectorMarkdown(p, '#s12:where(foo > foo, .bar > baz)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :where>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+		]);
+	});
+
+	test('has, not, is specificity', function () {
+		assertSelectorMarkdown(p, '#s12:not(foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :not>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+		]);
+		assertSelectorMarkdown(p, '#s12:not(foo > foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :not>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+		]);
+		assertSelectorMarkdown(p, '#s12:not(foo > foo, .bar > baz)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :not>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+		]);
+
+		assertSelectorMarkdown(p, '#s12:has(foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :has>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+		]);
+		assertSelectorMarkdown(p, '#s12:has(foo > foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :has>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+		]);
+		assertSelectorMarkdown(p, '#s12:has(foo > foo, .bar > baz)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :has>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+		]);
+
+		assertSelectorMarkdown(p, '#s12:is(foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :is>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+		]);
+		assertSelectorMarkdown(p, '#s12:is(foo > foo)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :is>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+		]);
+		assertSelectorMarkdown(p, '#s12:is(foo > foo, .bar > baz)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :is>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+		]);
+
+		assertSelectorMarkdown(p, '#s12:is(foo > foo, :not(.bar > baz, :has(.bar > .baz)))', '#s12', [
+			{ language: 'html', value: '<element id="s12" :is>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 2, 0)'
+		]);
+	});
 });


### PR DESCRIPTION
fixes : https://github.com/microsoft/vscode-css-languageservice/issues/248

- `:has`, `:is` and `:not` now get the specificity of the most specific list item.
- `:where` always adds zero specificity

<img width="213" alt="Screenshot 2022-02-09 at 09 19 07" src="https://user-images.githubusercontent.com/11521496/153154288-dddde5c2-627c-4ddd-ad00-099b0b212bb4.png">

<img width="231" alt="Screenshot 2022-02-09 at 00 18 27" src="https://user-images.githubusercontent.com/11521496/153091939-bc7f6fe4-9280-4388-9ae6-3649ff92a736.png">

