### PR TITLE
fix selector specificity display for `:lang` and similar pseudo selectors

### DIFF
--- a/build/copy-jsbeautify.js
+++ b/build/copy-jsbeautify.js
@@ -16,14 +16,6 @@ function copy(from, to) {
 	}
 }
 
-if (!fs.existsSync(path.join(__dirname, '..', 'lib', 'umd'))) {
-	fs.mkdirSync(path.join(__dirname, '..', 'lib', 'umd'));
-}
-
-if (!fs.existsSync(path.join(__dirname, '..', 'lib', 'esm'))) {
-	fs.mkdirSync(path.join(__dirname, '..', 'lib', 'esm'));
-}
-
 const umdDir = path.join(__dirname, '..', 'lib', 'umd', 'beautify');
 copy(path.join(__dirname, '..', 'src', 'beautify'), umdDir);
 

--- a/build/copy-jsbeautify.js
+++ b/build/copy-jsbeautify.js
@@ -16,6 +16,14 @@ function copy(from, to) {
 	}
 }
 
+if (!fs.existsSync(path.join(__dirname, '..', 'lib', 'umd'))) {
+	fs.mkdirSync(path.join(__dirname, '..', 'lib', 'umd'));
+}
+
+if (!fs.existsSync(path.join(__dirname, '..', 'lib', 'esm'))) {
+	fs.mkdirSync(path.join(__dirname, '..', 'lib', 'esm'));
+}
+
 const umdDir = path.join(__dirname, '..', 'lib', 'umd', 'beautify');
 copy(path.join(__dirname, '..', 'src', 'beautify'), umdDir);
 

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -388,7 +388,7 @@ export class SelectorPrinting {
 						const text = element.getText();
 						if (this.isPseudoElementIdentifier(text)) {
 							specificity.tag++;	// pseudo element
-							break;
+							continue elementLoop;
 						}
 
 						// where and child selectors have zero specificity
@@ -438,7 +438,7 @@ export class SelectorPrinting {
 						}
 
 						specificity.attr++;	//pseudo class
-						break;
+						continue elementLoop;
 				}
 
 				if (element.getChildren().length > 0) {

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -297,6 +297,11 @@ suite('CSS - MarkedStringPrinter selectors specificities', () => {
 			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
 		]);
 
+		assertSelectorMarkdown(p, '#s12:lang(en, fr)', '#s12', [
+			{ language: 'html', value: '<element id="s12" :lang>' },
+			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 0)'
+		]);
+
 		assertSelectorMarkdown(p, '#s12:is(foo > foo, :not(.bar > baz, :has(.bar > .baz)))', '#s12', [
 			{ language: 'html', value: '<element id="s12" :is>' },
 			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 2, 0)'


### PR DESCRIPTION
<img width="809" alt="Screenshot 2022-03-31 at 17 52 40" src="https://user-images.githubusercontent.com/11521496/161097495-944e3ed9-3946-4230-b1b9-6bfacaab3b3d.png">

https://drafts.csswg.org/selectors/#specificity-rules

> A few pseudo-classes provide “evaluation contexts” for other selectors, and so have their specificity defined specially:

With this change only those selectors with an `evaluation context` will have their child nodes counted.