### PR TITLE
sass-forward rule keyword "with"

### DIFF
--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -861,30 +861,6 @@ export class SCSSParser extends cssParser.Parser {
 			return this.finish(node, ParseError.StringLiteralExpected);
 		}
 
-		if (this.acceptIdent('with')) {
-			if (!this.accept(TokenType.ParenthesisL)) {
-				return this.finish(node, ParseError.LeftParenthesisExpected, [TokenType.ParenthesisR]);
-			}
-
-			// First variable statement, no comma.
-			if (!node.getParameters().addChild(this._parseModuleConfigDeclaration())) {
-				return this.finish(node, ParseError.VariableNameExpected);
-			}
-
-			while (this.accept(TokenType.Comma)) {
-				if (this.peek(TokenType.ParenthesisR)) {
-					break;
-				}
-				if (!node.getParameters().addChild(this._parseModuleConfigDeclaration())) {
-					return this.finish(node, ParseError.VariableNameExpected);
-				}
-			}
-
-			if (!this.accept(TokenType.ParenthesisR)) {
-				return this.finish(node, ParseError.RightParenthesisExpected);
-			}
-
-		}
 
 		if (!this.peek(TokenType.SemiColon) && !this.peek(TokenType.EOF)) {
 			if (!this.peekRegExp(TokenType.Ident, /as|hide|show/)) {
@@ -901,6 +877,37 @@ export class SCSSParser extends cssParser.Parser {
 				if (this.hasWhitespace() || !this.acceptDelim('*')) {
 					return this.finish(node, ParseError.WildcardExpected);
 				}
+
+				if (this.peekIdent('with')) {
+					if (!this.accept(TokenType.ParenthesisL)) {
+						return this.finish(node, ParseError.LeftParenthesisExpected, [TokenType.ParenthesisR]);
+					}
+				}
+			}
+
+			if (this.acceptIdent('with')) {
+				if (!this.accept(TokenType.ParenthesisL)) {
+					return this.finish(node, ParseError.LeftParenthesisExpected, [TokenType.ParenthesisR]);
+				}
+
+				// First variable statement, no comma.
+				if (!node.getParameters().addChild(this._parseModuleConfigDeclaration())) {
+					return this.finish(node, ParseError.VariableNameExpected);
+				}
+
+				while (this.accept(TokenType.Comma)) {
+					if (this.peek(TokenType.ParenthesisR)) {
+						break;
+					}
+					if (!node.getParameters().addChild(this._parseModuleConfigDeclaration())) {
+						return this.finish(node, ParseError.VariableNameExpected);
+					}
+				}
+
+				if (!this.accept(TokenType.ParenthesisR)) {
+					return this.finish(node, ParseError.RightParenthesisExpected);
+				}
+
 			}
 
 			if (this.peekIdent('hide') || this.peekIdent('show')) {
@@ -937,3 +944,4 @@ export class SCSSParser extends cssParser.Parser {
 	}
 
 }
+


### PR DESCRIPTION
This PR works to resolve https://github.com/microsoft/vscode/issues/145108. The implementations looks to see if "with" follows keyword "as" and resolves the "semicolon expected" error present in the issue.