### PR TITLE
selectors may start with combinators

### DIFF
--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -1413,10 +1413,10 @@ export class Parser {
 			if (!this.hasWhitespace() && this.accept(TokenType.ParenthesisL)) {
 				const tryAsSelector = () => {
 					const selectors = this.create(nodes.Node);
-					if (!selectors.addChild(this._parseSelector(false))) {
+					if (!selectors.addChild(this._parseSelector(true))) {
 						return null;
 					}
-					while (this.accept(TokenType.Comma) && selectors.addChild(this._parseSelector(false))) {
+					while (this.accept(TokenType.Comma) && selectors.addChild(this._parseSelector(true))) {
 						// loop
 					}
 					if (this.peek(TokenType.ParenthesisR)) {

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -399,6 +399,10 @@ suite('CSS - Parser', () => {
 		assertNode(':global(.output ::selection)', parser, parser._parsePseudo.bind(parser)); // #49010
 		assertNode(':matches(:hover, :focus)', parser, parser._parsePseudo.bind(parser)); // #49010
 		assertNode(':host([foo=bar][bar=foo])', parser, parser._parsePseudo.bind(parser)); // #49589
+		assertNode(':has(> .test)', parser, parser._parsePseudo.bind(parser)); // #250
+		assertNode(':has(~ .test)', parser, parser._parsePseudo.bind(parser)); // #250
+		assertNode(':has(+ .test)', parser, parser._parsePseudo.bind(parser)); // #250
+		assertNode(':has(~ div .test)', parser, parser._parsePseudo.bind(parser)); // #250
 		assertError('::', parser, parser._parsePseudo.bind(parser), ParseError.IdentifierExpected);
 		assertError(':: foo', parser, parser._parsePseudo.bind(parser), ParseError.IdentifierExpected);
 	});


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/147353  
fixes #250

A minor change that removes syntax errors when selectors start with combinators (ex: `>`, `~`, and `+`). 