### PR TITLE
work on LanguageService.findDocumentSymbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-
+6.1.0 / 
+================
+ * new API `LanguageService.findDocumentSymbols2`, returning `DocumentSymbol[]`
 
 6.0.0 / 2022-05-18
 ================

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "js-beautify": "^1.14.6",
     "mocha": "^10.0.0",
     "rimraf": "^3.0.2",
+    "source-map-support": "^0.5.21",
     "typescript": "^4.5.5"
   },
   "dependencies": {
@@ -40,8 +41,8 @@
     "clean": "rimraf lib",
     "remove-sourcemap-refs": "node ./build/remove-sourcemap-refs.js",
     "watch": "npm run copy-jsbeautify && tsc -w -p ./src",
-    "test": "npm run compile && mocha",
-    "mocha": "mocha",
+    "test": "npm run compile && npm run mocha",
+    "mocha": "mocha --require source-map-support/register",
     "coverage": "npm run compile && npx nyc --reporter=html --reporter=text  mocha",
     "lint": "eslint src/**/*.ts",
     "update-data": "yarn add @vscode/web-custom-data -D && node ./build/generateData.js",

--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -23,7 +23,7 @@ import {
 	Diagnostic, Position, CompletionList, Hover, Location, DocumentHighlight, DocumentLink,
 	SymbolInformation, Range, CodeActionContext, Command, CodeAction, ColorInformation,
 	Color, ColorPresentation, WorkspaceEdit, FoldingRange, SelectionRange, TextDocument,
-	ICSSDataProvider, CSSDataV1, HoverSettings, CompletionSettings, TextEdit, CSSFormatConfiguration
+	ICSSDataProvider, CSSDataV1, HoverSettings, CompletionSettings, TextEdit, CSSFormatConfiguration, DocumentSymbol
 } from './cssLanguageTypes';
 
 import { CSSDataManager } from './languageFacts/dataManager';
@@ -53,6 +53,7 @@ export interface LanguageService {
 	 */
 	findDocumentLinks2(document: TextDocument, stylesheet: Stylesheet, documentContext: DocumentContext): Promise<DocumentLink[]>;
 	findDocumentSymbols(document: TextDocument, stylesheet: Stylesheet): SymbolInformation[];
+	findDocumentSymbols2(document: TextDocument, stylesheet: Stylesheet): DocumentSymbol[];
 	doCodeActions(document: TextDocument, range: Range, context: CodeActionContext, stylesheet: Stylesheet): Command[];
 	doCodeActions2(document: TextDocument, range: Range, context: CodeActionContext, stylesheet: Stylesheet): CodeAction[];
 	findDocumentColors(document: TextDocument, stylesheet: Stylesheet): ColorInformation[];
@@ -92,7 +93,8 @@ function createFacade(parser: Parser, completion: CSSCompletion, hover: CSSHover
 		findDocumentHighlights: navigation.findDocumentHighlights.bind(navigation),
 		findDocumentLinks: navigation.findDocumentLinks.bind(navigation),
 		findDocumentLinks2: navigation.findDocumentLinks2.bind(navigation),
-		findDocumentSymbols: navigation.findDocumentSymbols.bind(navigation),
+		findDocumentSymbols: navigation.findSymbolInformations.bind(navigation),
+		findDocumentSymbols2: navigation.findDocumentSymbols.bind(navigation),
 		doCodeActions: codeActions.doCodeActions.bind(codeActions),
 		doCodeActions2: codeActions.doCodeActions2.bind(codeActions),
 		findDocumentColors: navigation.findDocumentColors.bind(navigation),

--- a/src/parser/cssNodes.ts
+++ b/src/parser/cssNodes.ts
@@ -1187,17 +1187,8 @@ export class Document extends BodyDeclaration {
 }
 
 export class Medialist extends Node {
-	private mediums?: Nodelist;
-
 	constructor(offset: number, length: number) {
 		super(offset, length);
-	}
-
-	public getMediums(): Nodelist {
-		if (!this.mediums) {
-			this.mediums = new Nodelist(this);
-		}
-		return this.mediums;
 	}
 }
 
@@ -1474,8 +1465,8 @@ export class NumericValue extends Node {
 
 export class VariableDeclaration extends AbstractDeclaration {
 
-	private variable: Variable | null = null;
-	private value: Node | null = null;
+	private variable: Variable | undefined;
+	private value: Node | undefined;
 	public needsSemicolon: boolean = true;
 
 	constructor(offset: number, length: number) {
@@ -1486,7 +1477,7 @@ export class VariableDeclaration extends AbstractDeclaration {
 		return NodeType.VariableDeclaration;
 	}
 
-	public setVariable(node: Variable | null): node is Variable {
+	public setVariable(node: Variable | undefined | null): node is Variable {
 		if (node) {
 			node.attachTo(this);
 			this.variable = node;
@@ -1495,7 +1486,7 @@ export class VariableDeclaration extends AbstractDeclaration {
 		return false;
 	}
 
-	public getVariable(): Variable | null {
+	public getVariable(): Variable | undefined {
 		return this.variable;
 	}
 
@@ -1503,7 +1494,7 @@ export class VariableDeclaration extends AbstractDeclaration {
 		return this.variable ? this.variable.getName() : '';
 	}
 
-	public setValue(node: Node | null): node is Node {
+	public setValue(node: Node | undefined | null): node is Node {
 		if (node) {
 			node.attachTo(this);
 			this.value = node;
@@ -1512,7 +1503,7 @@ export class VariableDeclaration extends AbstractDeclaration {
 		return false;
 	}
 
-	public getValue(): Node | null {
+	public getValue(): Node | undefined {
 		return this.value;
 	}
 }

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -853,7 +853,7 @@ export class CSSCompletion {
 
 	public getCompletionsForVariableDeclaration(declaration: nodes.VariableDeclaration, result: CompletionList): CompletionList {
 		if (this.offset && isDefined(declaration.colonPosition) && this.offset > declaration.colonPosition) {
-			this.getVariableProposals(declaration.getValue(), result);
+			this.getVariableProposals(declaration.getValue() || null, result);
 		}
 		return result;
 	}

--- a/src/test/css/navigation.test.ts
+++ b/src/test/css/navigation.test.ts
@@ -250,6 +250,12 @@ suite('CSS - Navigation', () => {
 			assertSymbols(ls, '.foo {}', [{ name: '.foo', kind: SymbolKind.Class, location: Location.create('test://test/test.css', newRange(0, 7)) }]);
 			assertSymbols(ls, '.foo:not(.selected) {}', [{ name: '.foo:not(.selected)', kind: SymbolKind.Class, location: Location.create('test://test/test.css', newRange(0, 22)) }]);
 
+			// multiple selectors, each range starts with the selector offset
+			assertSymbols(ls, '.voo.doo, .bar {}', [
+				{ name: '.voo.doo', kind: SymbolKind.Class, location: Location.create('test://test/test.css', newRange(0, 17)) },
+				{ name: '.bar', kind: SymbolKind.Class, location: Location.create('test://test/test.css', newRange(10, 17)) },
+			]);
+
 			// Media Query
 			assertSymbols(ls, '@media screen, print {}', [{ name: '@media screen, print', kind: SymbolKind.Module, location: Location.create('test://test/test.css', newRange(0, 23)) }]);
 		});

--- a/src/test/less/lessNavigation.test.ts
+++ b/src/test/less/lessNavigation.test.ts
@@ -56,8 +56,7 @@ suite('LESS - Symbols', () => {
 	test('basic symbols', () => {
 		let ls = getLESSLanguageService();
 		assertSymbols(ls, '.a(@gutter: @gutter-width) { &:extend(.b); }', [
-			{ name: '.a', kind: SymbolKind.Method, location: Location.create('test://test/test.css', newRange(0, 44)) },
-			{ name: '.b', kind: SymbolKind.Class, location: Location.create('test://test/test.css', newRange(29, 41)) }
+			{ name: '.a', kind: SymbolKind.Method, location: Location.create('test://test/test.css', newRange(0, 44)) }
 		]);
 	});
 

--- a/src/test/less/lessNavigation.test.ts
+++ b/src/test/less/lessNavigation.test.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as nodes from '../../parser/cssNodes';
-import { assertScopeBuilding, assertSymbolsInScope, assertScopesAndSymbols, assertHighlights, assertSymbols, newRange, assertColorSymbols } from '../css/navigation.test';
+import { assertScopeBuilding, assertSymbolsInScope, assertScopesAndSymbols, assertHighlights, assertSymbolInfos, newRange, assertColorSymbols, assertDocumentSymbols } from '../css/navigation.test';
 import { getLESSLanguageService, SymbolKind, Location } from '../../cssLanguageService';
 import { colorFrom256RGB } from '../../languageFacts/facts';
 
@@ -55,8 +55,25 @@ suite('LESS - Symbols', () => {
 
 	test('basic symbols', () => {
 		let ls = getLESSLanguageService();
-		assertSymbols(ls, '.a(@gutter: @gutter-width) { &:extend(.b); }', [
+		assertSymbolInfos(ls, '.a(@gutter: @gutter-width) { &:extend(.b); }', [
 			{ name: '.a', kind: SymbolKind.Method, location: Location.create('test://test/test.css', newRange(0, 44)) }
+		]);
+		assertDocumentSymbols(ls, '.a(@gutter: @gutter-width) { &:extend(.b); }', [
+			{ name: '.a', kind: SymbolKind.Method, range: newRange(0, 44), selectionRange: newRange(0, 2) }
+		]);
+
+		assertSymbolInfos(ls, '.mixin() { .nested() {} }', [
+			{ name: '.mixin', kind: SymbolKind.Method, location: Location.create('test://test/test.css', newRange(0, 25)) },
+			{ name: '.nested', kind: SymbolKind.Method, location: Location.create('test://test/test.css', newRange(11, 23)) }
+		]);
+
+		assertDocumentSymbols(ls, '.mixin() { .nested() {} }', [
+			{
+				name: '.mixin', kind: SymbolKind.Method, range: newRange(0, 25), selectionRange: newRange(0, 6),
+				children: [
+					{ name: '.nested', kind: SymbolKind.Method, range: newRange(11, 23), selectionRange: newRange(11, 18) }
+				]
+			}
 		]);
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,11 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1180,6 +1185,19 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 string-width@^4.1.0:
   version "4.2.2"


### PR DESCRIPTION
- DocumentSymbols range for selectors now start with the start offset of the selector. For microsoft/vscode#157356
- some fixes: No longer selector reference from extends
- added LanguageService.findDocumentSymbols2 returning DocumentSymbol[]. Fixes #277