### PR TITLE
Add aspect-ratio as default valid property

### DIFF
--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -56,7 +56,9 @@ export class LintVisitor implements nodes.IVisitor {
 		this.settings = settings;
 		this.documentText = document.getText();
 		this.keyframes = new NodesByRootMap();
-		this.validProperties = {};
+		this.validProperties = {
+			'aspect-ratio': true,
+		};
 
 		const properties = settings.getSetting(Settings.ValidProperties);
 		if (Array.isArray(properties)) {


### PR DESCRIPTION
Hi, thanks for this repo 🙌 (and all of the other packages and projects that make up the Microsoft developer tooling ecosystem). Really amazing.

A quick PR to avoid the problem that `aspect-ratio` is not recognized as a valid property via [`typescript-styled-plugin`](https://github.com/microsoft/typescript-styled-plugin) and [`vscode-styled-components`](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components):

<img width="473" alt="Screenshot 2022-11-21 at 14 05 28" src="https://user-images.githubusercontent.com/1935696/203062667-df167413-8d1d-4741-8bc2-c6c0ccd89ce8.png">

Coming over from:

- https://github.com/microsoft/typescript-styled-plugin/issues/58
- https://github.com/styled-components/vscode-styled-components/issues/190

`aspect-ratio` docs: 
https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio

cc @mjbvz @aeschli