### PR TITLE
new CSS units

### DIFF
--- a/src/languageFacts/builtinData.ts
+++ b/src/languageFacts/builtinData.ts
@@ -129,7 +129,7 @@ export const basicShapeFunctions: { [name: string]: string } = {
 };
 
 export const units: { [unitName: string]: string[] } = {
-	'length': ['cap', 'ch', 'cm', 'cqb', 'cqh', 'cqi', 'cqmax', 'cqmin', 'cqw', 'dvb', 'dvh', 'dvi', 'dvw', 'em', 'ex', 'ic', 'in', 'lh', 'lvb', 'lvh', 'lvi', 'lvw', 'mm', 'pc', 'pt', 'px', 'q', 'rcap', 'rch', 'rem', 'rex', 'ric', 'svb', 'svh', 'svi', 'svw', 'vb', 'vh', 'vi', 'vmax', 'vmin', 'vw'],
+	'length': ['cap', 'ch', 'cm', 'cqb', 'cqh', 'cqi', 'cqmax', 'cqmin', 'cqw', 'dvb', 'dvh', 'dvi', 'dvw', 'em', 'ex', 'ic', 'in', 'lh', 'lvb', 'lvh', 'lvi', 'lvw', 'mm', 'pc', 'pt', 'px', 'q', 'rem', 'svb', 'svh', 'svi', 'svw', 'vb', 'vh', 'vi', 'vmax', 'vmin', 'vw'],
 	'angle': ['deg', 'rad', 'grad', 'turn'],
 	'time': ['ms', 's'],
 	'frequency': ['Hz', 'kHz'],

--- a/src/languageFacts/builtinData.ts
+++ b/src/languageFacts/builtinData.ts
@@ -129,7 +129,7 @@ export const basicShapeFunctions: { [name: string]: string } = {
 };
 
 export const units: { [unitName: string]: string[] } = {
-	'length': ['em', 'rem', 'ex', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'ch', 'vw', 'vh', 'vmin', 'vmax'],
+	'length': ['cap', 'ch', 'cm', 'cqb', 'cqh', 'cqi', 'cqmax', 'cqmin', 'cqw', 'dvb', 'dvh', 'dvi', 'dvw', 'em', 'ex', 'ic', 'in', 'lh', 'lvb', 'lvh', 'lvi', 'lvw', 'mm', 'pc', 'pt', 'px', 'q', 'rcap', 'rch', 'rem', 'rex', 'ric', 'svb', 'svh', 'svi', 'svw', 'vb', 'vh', 'vi', 'vmax', 'vmin', 'vw'],
 	'angle': ['deg', 'rad', 'grad', 'turn'],
 	'time': ['ms', 's'],
 	'frequency': ['Hz', 'kHz'],


### PR DESCRIPTION
Update CSS units with what is currently documented on MDN :
https://developer.mozilla.org/en-US/docs/Web/CSS/length

- [cap](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cap)
- [ch](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ch)
- [cm](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cm)
- [cqb](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqb)
- [cqh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqh)
- [cqi](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqi)
- [cqmax](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqmax)
- [cqmin](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqmin)
- [cqw](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cqw)
- [dvb](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vb)
- [dvh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh)
- [dvi](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vi)
- [dvw](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw)
- [em](https://developer.mozilla.org/en-US/docs/Web/CSS/length#em)
- [ex](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex)
- [ic](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ic)
- [in](https://developer.mozilla.org/en-US/docs/Web/CSS/length#in)
- [lh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#lh)
- [lvb](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vb)
- [lvh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh)
- [lvi](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vi)
- [lvw](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw)
- [mm](https://developer.mozilla.org/en-US/docs/Web/CSS/length#mm)
- [pc](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pc)
- [pt](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pt)
- [px](https://developer.mozilla.org/en-US/docs/Web/CSS/length#px)
- [q](https://developer.mozilla.org/en-US/docs/Web/CSS/length#q)
- [rem](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem)
- [svb](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vb)
- [svh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh)
- [svi](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vi)
- [svw](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw)
- [vb](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vb)
- [vh](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh)
- [vi](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vi)
- [vmax](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmax)
- [vmin](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmin)
- [vw](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw)