### PR TITLE
Only translate `Selector Specificity`

### DIFF
--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -450,8 +450,8 @@ export class SelectorPrinting {
 			return specificity;
 		};
 
-		const specificity = calculateScore(node);;
-		return l10n.t("[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): ({0}, {1}, {2})", specificity.id, specificity.attr, specificity.tag);
+		const specificity = calculateScore(node);
+		return `[${l10n.t("Selector Specificity")}](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (${specificity.id}), ${specificity.attr}, ${specificity.tag}`;
 	}
 
 }

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -451,7 +451,7 @@ export class SelectorPrinting {
 		};
 
 		const specificity = calculateScore(node);
-		return `[${l10n.t("Selector Specificity")}](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (${specificity.id}), ${specificity.attr}, ${specificity.tag}`;
+		return `[${l10n.t("Selector Specificity")}](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (${specificity.id}), ${specificity.attr}, ${specificity.tag})`;
 	}
 
 }


### PR DESCRIPTION
Only translate `Selector Specificity`

Fixes https://github.com/microsoft/vscode/issues/172278