### PR TITLE
Remove all `en-US`s in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ License
 
 Copyright 2016, 20 Microsoft
 
-With the exceptions of `build/mdn-documentation.js`, which is built upon content from [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web)
+With the exceptions of `build/mdn-documentation.js`, which is built upon content from [Mozilla Developer Network](https://developer.mozilla.org/docs/Web)
 and distributed under CC BY-SA 2.5.

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -451,7 +451,7 @@ export class SelectorPrinting {
 		};
 
 		const specificity = calculateScore(node);
-		return `[${l10n.t("Selector Specificity")}](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (${specificity.id}, ${specificity.attr}, ${specificity.tag})`;
+		return `[${l10n.t("Selector Specificity")}](https://developer.mozilla.org/docs/Web/CSS/Specificity): (${specificity.id}, ${specificity.attr}, ${specificity.tag})`;
 	}
 
 }

--- a/src/test/css/customData.test.ts
+++ b/src/test/css/customData.test.ts
@@ -19,12 +19,12 @@ suite('CSS - Custom Data', async () => {
 				name: 'foo',
 				description: {
 					kind: 'markdown',
-					value: 'Foo property. See link on [MDN](https://developer.mozilla.org/en-US/).',
+					value: 'Foo property. See link on [MDN](https://developer.mozilla.org/).',
 				},
 				references: [
 					{
 						name: 'MDN Reference',
-						url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/foo'
+						url: 'https://developer.mozilla.org/docs/Web/CSS/foo'
 					}
 				]
 			}
@@ -64,7 +64,7 @@ suite('CSS - Custom Data', async () => {
 					resultText: 'body { foo: $0; }',
 					documentation: {
 						kind: 'markdown',
-						value: 'Foo property. See link on [MDN](https://developer.mozilla.org/en-US/).\n\n[MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/foo)'
+						value: 'Foo property. See link on [MDN](https://developer.mozilla.org/).\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/CSS/foo)'
 					}
 				}
 			]

--- a/src/test/css/hover.test.ts
+++ b/src/test/css/hover.test.ts
@@ -65,7 +65,7 @@ suite('CSS Hover', () => {
 		assertHover('.|foo {}', {
 			contents: [
 				{ language: 'html', value: '<element class="foo">' },
-				'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 0)'
+				'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 1, 0)'
 			]
 		});
 	});
@@ -78,7 +78,7 @@ suite('SCSS Hover', () => {
 			{
 				contents: [
 					{ language: 'html', value: '<div>\n  …\n    <div>' },
-					'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+					'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)'
 				]
 			},
 			'scss'

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -137,40 +137,40 @@ suite('CSS - MarkedStringPrinter selectors', () => {
 		let p = new Parser();
 		assertSelectorMarkdown(p, 'e1 e2 { }', 'e1', [
 			{ language: 'html', value: '<e1>\n  …\n    <e2>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, 'e1 .div { }', 'e1', [
 			{ language: 'html', value: '<e1>\n  …\n    <element class="div">' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 1, 1)'
 		]);
 	});
 	test('child selector', function () {
 		let p = new Parser();
 		assertSelectorMarkdown(p, 'e1 > e2 { }', 'e2', [
 			{ language: 'html', value: '<e1>\n  <e2>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 	});
 	test('group selector', function () {
 		let p = new Parser();
 		assertSelectorMarkdown(p, 'e1, e2 { }', 'e1', [
 			{ language: 'html', value: '<e1>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)'
 		]);
 		assertSelectorMarkdown(p, 'e1, e2 { }', 'e2', [
 			{ language: 'html', value: '<e2>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)'
 		]);
 	});
 	test('sibling selector', function () {
 		let p = new Parser();
 		assertSelectorMarkdown(p, 'e1 + e2 { }', 'e2', [
 			{ language: 'html', value: '<e1>\n<e2>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, 'e1 ~ e2 { }', 'e2', [
 			{ language: 'html', value: '<e1>\n⋮\n<e2>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 	});
 });
@@ -180,131 +180,131 @@ suite('CSS - MarkedStringPrinter selectors specificities', () => {
 	test('attribute selector', function () {
 		assertSelectorMarkdown(p, 'h1 + *[rel=up]', 'h1', [
 			{ language: 'html', value: '<h1>\n<element rel="up">' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 1, 1)'
 		]);
 	});
 
 	test('class selector', function () {
 		assertSelectorMarkdown(p, 'ul ol li.red', 'ul', [
 			{ language: 'html', value: '<ul>\n  …\n    <ol>\n      …\n        <li class="red">' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 3)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 1, 3)'
 		]);
 		assertSelectorMarkdown(p, 'li.red.level', 'li', [
 			{ language: 'html', value: '<li class="red level">' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 2, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 2, 1)'
 		]);
 	});
 
 	test('pseudo class selector', function () {
 		assertSelectorMarkdown(p, 'p:focus', 'p', [
 			{ language: 'html', value: '<p :focus>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 1, 1)'
 		]);
 	});
 
 	test('element selector', function () {
 		assertSelectorMarkdown(p, 'li', 'li', [
 			{ language: 'html', value: '<li>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)'
 		]);
 		assertSelectorMarkdown(p, 'ul li', 'ul', [
 			{ language: 'html', value: '<ul>\n  …\n    <li>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, 'ul ol+li', 'ul', [
 			{ language: 'html', value: '<ul>\n  …\n    <ol>\n    <li>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 3)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 3)'
 		]);
 	});
 
 	test('pseudo element selector', function () {
 		assertSelectorMarkdown(p, 'p::after', 'p', [
 			{ language: 'html', value: '<p ::after>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, 'p:after', 'p', [
 			{ language: 'html', value: '<p :after>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 2)'
 		]);
 	});
 
 	test('identifier selector', function () {
 		assertSelectorMarkdown(p, '#x34y', '#x34y', [
 			{ language: 'html', value: '<element id="x34y">' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 0)'
 		]);
 	});
 
 	test('ignore universal and not selector', function () {
 		assertSelectorMarkdown(p, '*', '*', [
 			{ language: 'html', value: '<element>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 0)'
 		]);
 		assertSelectorMarkdown(p, '#s12:not(foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :not>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 1)'
 		]);
 	});
 
 	test('where specificity', function () {
 		assertSelectorMarkdown(p, '#s12:where(foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :where>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 0)'
 		]);
 		assertSelectorMarkdown(p, '#s12:where(foo > foo, .bar > baz)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :where>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 0)'
 		]);
 	});
 
 	test('has, not, is specificity', function () {
 		assertSelectorMarkdown(p, '#s12:not(foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :not>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 1)'
 		]);
 		assertSelectorMarkdown(p, '#s12:not(foo > foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :not>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, '#s12:not(foo > foo, .bar > baz)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :not>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 1)'
 		]);
 
 		assertSelectorMarkdown(p, '#s12:has(foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :has>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 1)'
 		]);
 		assertSelectorMarkdown(p, '#s12:has(foo > foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :has>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, '#s12:has(foo > foo, .bar > baz)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :has>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 1)'
 		]);
 
 		assertSelectorMarkdown(p, '#s12:is(foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :is>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 1)'
 		]);
 		assertSelectorMarkdown(p, '#s12:is(foo > foo)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :is>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 0, 2)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 2)'
 		]);
 		assertSelectorMarkdown(p, '#s12:is(foo > foo, .bar > baz)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :is>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 1)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 1)'
 		]);
 
 		assertSelectorMarkdown(p, '#s12:lang(en, fr)', '#s12', [
 			{ language: 'html', value: '<element id="s12" :lang>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 1, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 0)'
 		]);
 
 		assertSelectorMarkdown(p, '#s12:is(foo > foo, :not(.bar > baz, :has(.bar > .baz)))', '#s12', [
 			{ language: 'html', value: '<element id="s12" :is>' },
-			'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (1, 2, 0)'
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 0)'
 		]);
 	});
 });


### PR DESCRIPTION
That way, when a user opens the link, it goes to the page in that user's configured language.