### PR TITLE
MixinContentDeclaration returns the wrong type

### DIFF
--- a/src/parser/cssNodes.ts
+++ b/src/parser/cssNodes.ts
@@ -1639,7 +1639,7 @@ export class MixinContentDeclaration extends BodyDeclaration {
 	}
 
 	public get type(): NodeType {
-		return NodeType.MixinContentReference;
+		return NodeType.MixinContentDeclaration;
 	}
 
 	public getParameters(): Nodelist {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-css-languageservice/issues/351