### PR TITLE
add support for `::slotted`, `:host`, `:host-context`, `:nth-child(1n of .foo)` and `:nth-last-child(1n of .foo)`

### DIFF
--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -1548,7 +1548,18 @@ export class Parser {
 
 					return null;
 				};
-				node.addChild(this.try(tryAsSelector) || this._parseBinaryExpr());
+
+				let hasSelector = node.addChild(this.try(tryAsSelector));
+				if (!hasSelector) {
+					if (
+						node.addChild(this._parseBinaryExpr()) &&
+						this.acceptIdent('of') &&
+						!node.addChild(this.try(tryAsSelector))
+					) {
+						return this.finish(node, ParseError.SelectorExpected);
+					}
+				}
+
 				if (!this.accept(TokenType.ParenthesisR)) {
 					return this.finish(node, ParseError.RightParenthesisExpected);
 				}

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -434,6 +434,11 @@ suite('CSS - Parser', () => {
 		assertNode(':some', parser, parser._parsePseudo.bind(parser));
 		assertNode(':some(thing)', parser, parser._parsePseudo.bind(parser));
 		assertNode(':nth-child(12)', parser, parser._parsePseudo.bind(parser));
+		assertNode(':nth-child(1n)', parser, parser._parsePseudo.bind(parser));
+		assertNode(':nth-child(-n+3)', parser, parser._parsePseudo.bind(parser));
+		assertNode(':nth-child(2n+1)', parser, parser._parsePseudo.bind(parser));
+		assertNode(':nth-child(2n+1 of .foo)', parser, parser._parsePseudo.bind(parser));
+		assertNode(':nth-child(2n+1 of .foo > bar, :not(*) ~ [other="value"])', parser, parser._parsePseudo.bind(parser));
 		assertNode(':lang(it)', parser, parser._parsePseudo.bind(parser));
 		assertNode(':not(.class)', parser, parser._parsePseudo.bind(parser));
 		assertNode(':not(:disabled)', parser, parser._parsePseudo.bind(parser));
@@ -449,6 +454,7 @@ suite('CSS - Parser', () => {
 		assertNode(':has(~ div .test)', parser, parser._parsePseudo.bind(parser)); // #250
 		assertError('::', parser, parser._parsePseudo.bind(parser), ParseError.IdentifierExpected);
 		assertError(':: foo', parser, parser._parsePseudo.bind(parser), ParseError.IdentifierExpected);
+		assertError(':nth-child(1n of)', parser, parser._parsePseudo.bind(parser), ParseError.SelectorExpected);
 	});
 
 	test('declaration', function () {

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -307,4 +307,35 @@ suite('CSS - MarkedStringPrinter selectors specificities', () => {
 			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 0)'
 		]);
 	});
+
+	test('nth-child, nth-last-child specificity', function () {
+		assertSelectorMarkdown(p, '#foo:nth-child(-n+3 of li.important)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 1)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-last-child(-n+3 of li, .important)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-last-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 0)'
+		]);
+	});
+
+	test('host, host-context specificity', function () {
+		assertSelectorMarkdown(p, '#foo:host(.foo)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :host>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 0)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:host-context(foo)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :host-context>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 1)'
+		]);
+	});
+
+	test('slotted specificity', function () {
+		assertSelectorMarkdown(p, '#foo::slotted(foo)', '#foo', [
+			{ language: 'html', value: '<element id="foo" ::slotted>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 0, 2)'
+		]);
+	});
 });


### PR DESCRIPTION
- `::slotted`
- `:host`
- `:host-context`
- `:nth-child(1n of .foo)`
- `:nth-last-child(1n of .foo)`

------

fixes : https://github.com/microsoft/vscode-css/issues/13

<img width="414" alt="Screenshot 2023-06-12 at 19 09 10" src="https://github.com/microsoft/vscode-css-languageservice/assets/11521496/e28e7f98-0101-4952-ae9e-add2e3068774">
