### PR TITLE
#74068 nth child specificity

### DIFF
--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -470,7 +470,7 @@ export class SelectorPrinting {
 						}
 
 						if (text.match(/^:(?:nth-child|nth-last-child)/i) && childElements.length > 0) {
-							// The specificity of the :nth-child(An+B [of S]?) pseudo-class is the specificity of a single pseudo-class plus, if S is specified, the specificity of the most specific complex selector in S
+							/* The specificity of the :nth-child(An+B [of S]?) pseudo-class is the specificity of a single pseudo-class plus, if S is specified, the specificity of the most specific complex selector in S */
 							// https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo
 							specificity.attr++;
 

--- a/src/services/selectorPrinting.ts
+++ b/src/services/selectorPrinting.ts
@@ -490,8 +490,6 @@ export class SelectorPrinting {
 							continue elementLoop;
 						}
 
-
-
 						specificity.attr++;	//pseudo class
 						continue elementLoop;
 				}

--- a/src/test/css/selectorPrinting.test.ts
+++ b/src/test/css/selectorPrinting.test.ts
@@ -309,9 +309,39 @@ suite('CSS - MarkedStringPrinter selectors specificities', () => {
 	});
 
 	test('nth-child, nth-last-child specificity', function () {
+		assertSelectorMarkdown(p, '#foo:nth-child(2)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 0)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-child(even)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 0)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-child(odd)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 0)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-child(-n + 2)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 0)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-child(n of li)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 1, 1)'
+		]);
+
 		assertSelectorMarkdown(p, '#foo:nth-child(-n+3 of li.important)', '#foo', [
 			{ language: 'html', value: '<element id="foo" :nth-child>' },
 			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 2, 1)'
+		]);
+
+		assertSelectorMarkdown(p, '#foo:nth-child(-n+3 of li.important, .class1.class2.class3)', '#foo', [
+			{ language: 'html', value: '<element id="foo" :nth-child>' },
+			'[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (1, 4, 0)'
 		]);
 
 		assertSelectorMarkdown(p, '#foo:nth-last-child(-n+3 of li, .important)', '#foo', [


### PR DESCRIPTION
Fix issue [#74068](https://github.com/microsoft/vscode/issues/74068) "[css] Wrong selector specificity values with :nth-child(even) and :nth-child(odd)". This patches the specificity for the nth-child/nth-last-child psuedo-selector. 

Debugging the code it seems the scanner/parser treats words 'even', 'odd', and 'n', as NodeType 16 (ElementNameSelector), which contributes to a false specificity. 

'div:nth-child(n of li)' should produce a specificity of 0-1-2, but produces 0-1-4 suggesting all three arguments are treated as elements. If the 'n' has an integer prefix the correct specificity is produced however.

Rather than try to unpack the scanner/parser logic, the solution exploits the formula of the psuedo-selector by testing for the presence of " of " within the arguments string, ["An+B [of S]?"](https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo). 

> The specificity of the :nth-child(An+B [of S]?) pseudo-class is the specificity of a single pseudo-class plus, if S is specified, the specificity of the most specific complex selector in S
