### PR TITLE
[scss] Path resolver to include partial files support

### DIFF
--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -44,8 +44,8 @@ export class SCSSNavigation extends CSSNavigation {
 }
 
 function toPathVariations(target: string): DocumentUri[] {
-	// No variation for links that ends with suffix
-	if (target.endsWith('.scss') || target.endsWith('.css')) {
+	// No variation for links that ends with .css suffix
+	if (target.endsWith('.css')) {
 		return [target];
 	}
 
@@ -54,7 +54,9 @@ function toPathVariations(target: string): DocumentUri[] {
 		return [target + 'index.scss', target + '_index.scss'];
 	}
 
-	const targetUri = URI.parse(target);
+	const targetWithoutScssExtension = target.replace(/\.scss$/, '');
+
+	const targetUri = URI.parse(targetWithoutScssExtension);
 	const basename = Utils.basename(targetUri);
 	const dirname = Utils.dirname(targetUri);
 	if (basename.startsWith('_')) {
@@ -65,8 +67,8 @@ function toPathVariations(target: string): DocumentUri[] {
 	return [
 		Utils.joinPath(dirname, basename + '.scss').toString(true),
 		Utils.joinPath(dirname, '_' + basename + '.scss').toString(true),
-		target + '/index.scss',
-		target + '/_index.scss',
+		targetWithoutScssExtension + '/index.scss',
+		targetWithoutScssExtension + '/_index.scss',
 		Utils.joinPath(dirname, basename + '.css').toString(true)
 	];
 }

--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -54,9 +54,7 @@ function toPathVariations(target: string): DocumentUri[] {
 		return [target + 'index.scss', target + '_index.scss'];
 	}
 
-	const targetWithoutScssExtension = target.replace(/\.scss$/, '');
-
-	const targetUri = URI.parse(targetWithoutScssExtension);
+	const targetUri = URI.parse(target.replace(/\.scss$/, ''));
 	const basename = Utils.basename(targetUri);
 	const dirname = Utils.dirname(targetUri);
 	if (basename.startsWith('_')) {
@@ -67,8 +65,8 @@ function toPathVariations(target: string): DocumentUri[] {
 	return [
 		Utils.joinPath(dirname, basename + '.scss').toString(true),
 		Utils.joinPath(dirname, '_' + basename + '.scss').toString(true),
-		targetWithoutScssExtension + '/index.scss',
-		targetWithoutScssExtension + '/_index.scss',
+		target + '/index.scss',
+		target + '/_index.scss',
 		Utils.joinPath(dirname, basename + '.css').toString(true)
 	];
 }

--- a/src/test/scss/scssNavigation.test.ts
+++ b/src/test/scss/scssNavigation.test.ts
@@ -140,6 +140,10 @@ suite('SCSS - Navigation', () => {
 				{ range: newRange(8, 13), target: getDocumentUri('./underscore/_foo.scss') }
 			]);
 
+			await assertDynamicLinks(getDocumentUri('./underscore/index.scss'), `@import 'foo.scss'`, [
+				{ range: newRange(8, 18), target: getDocumentUri('./underscore/_foo.scss') }
+			]);
+
 			await assertDynamicLinks(getDocumentUri('./both/index.scss'), `@import 'foo'`, [
 				{ range: newRange(8, 13), target: getDocumentUri('./both/foo.scss') }
 			]);


### PR DESCRIPTION
## Context

When importing [partials](https://sass-lang.com/documentation/at-rules/import/#partials) (e.g "_mixins.scss"), it's unnecessary to explicitly include the underscore (`_`). Sass inherently understands and imports files with or without the underscore. Therefore, `@import "mixins.scss"` is a valid way to import the partial.

## Why this change has been made?

Navigating to a partial file using `Command + Click` or `Control + Click` without specifying the underscore was causing the language server to be unable to find the path.

## Changes
- Update  `toPathVariations` function to consider partial files when the underscore has been omitted.
-  Add a new test case to ensure accurate resolution when the underscore is omitted when import partial files.

### Before
<img src="https://github.com/microsoft/vscode-css-languageservice/assets/7013779/12613f27-871a-46b3-aaf4-5652662a2551" alt="before" width="500px">

### After
<img src="https://github.com/microsoft/vscode-css-languageservice/assets/7013779/fe4b6fb6-c6ab-4575-b346-383901582b35" alt="after" width="500px">
