### PR TITLE
feat: add support for Sass `pkg:` importers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 lib/
 node_modules/
+!src/test/scss/linkFixture/pkgImport/node_modules/
 coverage/
 .nyc_output/
 npm-debug.log

--- a/src/cssLanguageTypes.ts
+++ b/src/cssLanguageTypes.ts
@@ -154,7 +154,7 @@ export namespace ClientCapabilities {
 
 export interface LanguageServiceOptions {
 	/**
-	 * Unless set to false, the default CSS data provider will be used 
+	 * Unless set to false, the default CSS data provider will be used
 	 * along with the providers from customDataProviders.
 	 * Defaults to true.
 	 */
@@ -284,7 +284,7 @@ export interface FileStat {
 export interface FileSystemProvider {
 	stat(uri: DocumentUri): Promise<FileStat>;
 	readDirectory?(uri: DocumentUri): Promise<[string, FileType][]>;
-	getContent?(uri: DocumentUri, encoding?: BufferEncoding): Promise<string>;
+	getContent?(uri: DocumentUri, encoding?: string): Promise<string>;
 }
 
 export interface CSSFormatConfiguration {
@@ -306,11 +306,11 @@ export interface CSSFormatConfiguration {
 	preserveNewLines?: boolean;
 	/** maximum number of line breaks to be preserved in one chunk. Default: unlimited */
 	maxPreserveNewLines?: number;
-    /** maximum amount of characters per line (0/undefined = disabled). Default: disabled. */
+	/** maximum amount of characters per line (0/undefined = disabled). Default: disabled. */
 	wrapLineLength?: number;
 	/** add indenting whitespace to empty lines. Default: false */
 	indentEmptyLines?: boolean;
-	
+
 	/** @deprecated Use newlineBetweenSelectors instead*/
 	selectorSeparatorNewline?: boolean;
 

--- a/src/cssLanguageTypes.ts
+++ b/src/cssLanguageTypes.ts
@@ -284,6 +284,7 @@ export interface FileStat {
 export interface FileSystemProvider {
 	stat(uri: DocumentUri): Promise<FileStat>;
 	readDirectory?(uri: DocumentUri): Promise<[string, FileType][]>;
+	getContent?(uri: DocumentUri, encoding?: BufferEncoding): Promise<string>;
 }
 
 export interface CSSFormatConfiguration {

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -396,86 +396,7 @@ export class CSSNavigation {
 		// look for the `exports` field of the module and any `sass`, `style` or `default` that matches the import.
 		// If it's only `pkg:module`, also look for `sass` and `style` on the root of package.json.
 		if (target.startsWith('pkg:')) {
-			const bareTarget = target.replace('pkg:', '');
-			const moduleName = bareTarget.includes('/') ? getModuleNameFromPath(bareTarget) : bareTarget;
-			const rootFolderUri = documentContext.resolveReference('/', documentUri);
-			const documentFolderUri = dirname(documentUri);
-			const modulePath = await this.resolvePathToModule(moduleName, documentFolderUri, rootFolderUri);
-			if (modulePath) {
-				const packageJsonPath = `${modulePath}/package.json`;
-				if (packageJsonPath) {
-					// Since submodule exports import strings don't match the file system,
-					// we need the contents of `package.json` to look up the correct path.
-					let packageJsonContent = await this.getContent(packageJsonPath);
-					if (packageJsonContent) {
-						const packageJson: {
-							style?: string;
-							sass?: string;
-							exports: Record<string, string | Record<string, string>>
-						} = JSON.parse(packageJsonContent);
-
-						const subpath = bareTarget.substring(moduleName.length + 1);
-						if (packageJson.exports) {
-							if (!subpath) {
-								// look for the default/index export
-								// @ts-expect-error If ['.'] is a string this just produces undefined
-								const entry = packageJson.exports['.']['sass'] || packageJson.exports['.']['style'] || packageJson.exports['.']['default'];
-								// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-								if (entry && entry.endsWith('.scss')) {
-									const entryPath = joinPath(modulePath, entry);
-									return entryPath;
-								}
-							} else {
-								// The import string may be with or without .scss.
-								// Likewise the exports entry. Look up both paths.
-								// However, they need to be relative (start with ./).
-								const lookupSubpath = subpath.endsWith('.scss') ? `./${subpath.replace('.scss', '')}` : `./${subpath}`;
-								const lookupSubpathScss = subpath.endsWith('.scss') ? `./${subpath}` : `./${subpath}.scss`;
-								const subpathObject = packageJson.exports[lookupSubpathScss] || packageJson.exports[lookupSubpath];
-								if (subpathObject) {
-									// @ts-expect-error If subpathObject is a string this just produces undefined
-									const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
-									// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-									if (entry && entry.endsWith('.scss')) {
-										const entryPath = joinPath(modulePath, entry);
-										return entryPath;
-									}
-								} else {
-									// We have a subpath, but found no matches on direct lookup.
-									// It may be a [subpath pattern](https://nodejs.org/api/packages.html#subpath-patterns).
-									for (const [maybePattern, subpathObject] of Object.entries(packageJson.exports)) {
-										if (!maybePattern.includes("*")) {
-											continue;
-										}
-										// Patterns may also be without `.scss` on the left side, so compare without on both sides
-										const re = new RegExp(maybePattern.replace('./', '\\.\/').replace('.scss', '').replace('*', '(.+)'));
-										const match = re.exec(lookupSubpath);
-										if (match) {
-											// @ts-expect-error If subpathObject is a string this just produces undefined
-											const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
-											// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-											if (entry && entry.endsWith('.scss')) {
-												// The right-hand side of a subpath pattern is also a pattern.
-												// Replace the pattern with the match from our regexp capture group above.
-												const expandedPattern = entry.replace('*', match[1]);
-												const entryPath = joinPath(modulePath, expandedPattern);
-												return entryPath;
-											}
-										}
-									}
-								}
-							}
-						} else if (!subpath && (packageJson.sass || packageJson.style)) {
-							// Fall back to a direct lookup on `sass` and `style` on package root
-							const entry = packageJson.sass || packageJson.style;
-							if (entry) {
-								const entryPath = joinPath(modulePath, entry);
-								return entryPath;
-							}
-						}
-					}
-				}
-			}
+			return this.resolvePkgModulePath(target, documentUri, documentContext);
 		}
 
 		const ref = await this.mapReference(documentContext.resolveReference(target, documentUri), isRawLink);
@@ -526,6 +447,90 @@ export class CSSNavigation {
 			return dirname(packPath);
 		} else if (rootFolderUri && documentFolderUri.startsWith(rootFolderUri) && (documentFolderUri.length !== rootFolderUri.length)) {
 			return this.resolvePathToModule(_moduleName, dirname(documentFolderUri), rootFolderUri);
+		}
+		return undefined;
+	}
+
+	private async resolvePkgModulePath(target: string, documentUri: string, documentContext: DocumentContext): Promise<string | undefined> {
+		const bareTarget = target.replace('pkg:', '');
+		const moduleName = bareTarget.includes('/') ? getModuleNameFromPath(bareTarget) : bareTarget;
+		const rootFolderUri = documentContext.resolveReference('/', documentUri);
+		const documentFolderUri = dirname(documentUri);
+		const modulePath = await this.resolvePathToModule(moduleName, documentFolderUri, rootFolderUri);
+		if (modulePath) {
+			const packageJsonPath = `${modulePath}/package.json`;
+			if (packageJsonPath) {
+				// Since submodule exports import strings don't match the file system,
+				// we need the contents of `package.json` to look up the correct path.
+				let packageJsonContent = await this.getContent(packageJsonPath);
+				if (packageJsonContent) {
+					const packageJson: {
+						style?: string;
+						sass?: string;
+						exports: Record<string, string | Record<string, string>>
+					} = JSON.parse(packageJsonContent);
+
+					const subpath = bareTarget.substring(moduleName.length + 1);
+					if (packageJson.exports) {
+						if (!subpath) {
+							// look for the default/index export
+							// @ts-expect-error If ['.'] is a string this just produces undefined
+							const entry = packageJson.exports['.']['sass'] || packageJson.exports['.']['style'] || packageJson.exports['.']['default'];
+							// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+							if (entry && entry.endsWith('.scss')) {
+								const entryPath = joinPath(modulePath, entry);
+								return entryPath;
+							}
+						} else {
+							// The import string may be with or without .scss.
+							// Likewise the exports entry. Look up both paths.
+							// However, they need to be relative (start with ./).
+							const lookupSubpath = subpath.endsWith('.scss') ? `./${subpath.replace('.scss', '')}` : `./${subpath}`;
+							const lookupSubpathScss = subpath.endsWith('.scss') ? `./${subpath}` : `./${subpath}.scss`;
+							const subpathObject = packageJson.exports[lookupSubpathScss] || packageJson.exports[lookupSubpath];
+							if (subpathObject) {
+								// @ts-expect-error If subpathObject is a string this just produces undefined
+								const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+								// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+								if (entry && entry.endsWith('.scss')) {
+									const entryPath = joinPath(modulePath, entry);
+									return entryPath;
+								}
+							} else {
+								// We have a subpath, but found no matches on direct lookup.
+								// It may be a [subpath pattern](https://nodejs.org/api/packages.html#subpath-patterns).
+								for (const [maybePattern, subpathObject] of Object.entries(packageJson.exports)) {
+									if (!maybePattern.includes("*")) {
+										continue;
+									}
+									// Patterns may also be without `.scss` on the left side, so compare without on both sides
+									const re = new RegExp(maybePattern.replace('./', '\\.\/').replace('.scss', '').replace('*', '(.+)'));
+									const match = re.exec(lookupSubpath);
+									if (match) {
+										// @ts-expect-error If subpathObject is a string this just produces undefined
+										const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+										// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+										if (entry && entry.endsWith('.scss')) {
+											// The right-hand side of a subpath pattern is also a pattern.
+											// Replace the pattern with the match from our regexp capture group above.
+											const expandedPattern = entry.replace('*', match[1]);
+											const entryPath = joinPath(modulePath, expandedPattern);
+											return entryPath;
+										}
+									}
+								}
+							}
+						}
+					} else if (!subpath && (packageJson.sass || packageJson.style)) {
+						// Fall back to a direct lookup on `sass` and `style` on package root
+						const entry = packageJson.sass || packageJson.style;
+						if (entry) {
+							const entryPath = joinPath(modulePath, entry);
+							return entryPath;
+						}
+					}
+				}
+			}
 		}
 		return undefined;
 	}

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -392,6 +392,92 @@ export class CSSNavigation {
 			return this.mapReference(await this.resolveModuleReference(target, documentUri, documentContext), isRawLink);
 		}
 
+		// Following the [sass package importer](https://github.com/sass/sass/blob/f6832f974c61e35c42ff08b3640ff155071a02dd/js-api-doc/importer.d.ts#L349),
+		// look for the `exports` field of the module and any `sass`, `style` or `default` that matches the import.
+		// If it's only `pkg:module`, also look for `sass` and `style` on the root of package.json.
+		if (target.startsWith('pkg:')) {
+			const bareTarget = target.replace('pkg:', '');
+			const moduleName = bareTarget.includes('/') ? getModuleNameFromPath(bareTarget) : bareTarget;
+			const rootFolderUri = documentContext.resolveReference('/', documentUri);
+			const documentFolderUri = dirname(documentUri);
+			const modulePath = await this.resolvePathToModule(moduleName, documentFolderUri, rootFolderUri);
+			if (modulePath) {
+				const packageJsonPath = `${modulePath}/package.json`;
+				if (packageJsonPath) {
+					// Since submodule exports import strings don't match the file system,
+					// we need the contents of `package.json` to look up the correct path.
+					let packageJsonContent = await this.getContent(packageJsonPath);
+					if (packageJsonContent) {
+						const packageJson: {
+							style?: string;
+							sass?: string;
+							exports: Record<string, string | Record<string, string>>
+						} = JSON.parse(packageJsonContent);
+
+						const subpath = bareTarget.substring(moduleName.length + 1);
+						if (packageJson.exports) {
+							if (!subpath) {
+								// look for the default/index export
+								// @ts-expect-error If ['.'] is a string this just produces undefined
+								const entry = packageJson.exports['.']['sass'] || packageJson.exports['.']['style'] || packageJson.exports['.']['default'];
+								// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+								if (entry && entry.endsWith('.scss')) {
+									const entryPath = joinPath(modulePath, entry);
+									return entryPath;
+								}
+							} else {
+								// The import string may be with or without .scss.
+								// Likewise the exports entry. Look up both paths.
+								// However, they need to be relative (start with ./).
+								const lookupSubpath = subpath.endsWith('.scss') ? `./${subpath.replace('.scss', '')}` : `./${subpath}`;
+								const lookupSubpathScss = subpath.endsWith('.scss') ? `./${subpath}` : `./${subpath}.scss`;
+								const subpathObject = packageJson.exports[lookupSubpathScss] || packageJson.exports[lookupSubpath];
+								if (subpathObject) {
+									// @ts-expect-error If subpathObject is a string this just produces undefined
+									const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+									// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+									if (entry && entry.endsWith('.scss')) {
+										const entryPath = joinPath(modulePath, entry);
+										return entryPath;
+									}
+								} else {
+									// We have a subpath, but found no matches on direct lookup.
+									// It may be a [subpath pattern](https://nodejs.org/api/packages.html#subpath-patterns).
+									for (const [maybePattern, subpathObject] of Object.entries(packageJson.exports)) {
+										if (!maybePattern.includes("*")) {
+											continue;
+										}
+										// Patterns may also be without `.scss` on the left side, so compare without on both sides
+										const re = new RegExp(maybePattern.replace('./', '\\.\/').replace('.scss', '').replace('*', '(.+)'));
+										const match = re.exec(lookupSubpath);
+										if (match) {
+											// @ts-expect-error If subpathObject is a string this just produces undefined
+											const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+											// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+											if (entry && entry.endsWith('.scss')) {
+												// The right-hand side of a subpath pattern is also a pattern.
+												// Replace the pattern with the match from our regexp capture group above.
+												const expandedPattern = entry.replace('*', match[1]);
+												const entryPath = joinPath(modulePath, expandedPattern);
+												return entryPath;
+											}
+										}
+									}
+								}
+							}
+						} else if (!subpath && (packageJson.sass || packageJson.style)) {
+							// Fall back to a direct lookup on `sass` and `style` on package root
+							const entry = packageJson.sass || packageJson.style;
+							if (entry) {
+								const entryPath = joinPath(modulePath, entry);
+								return entryPath;
+							}
+						}
+					}
+				}
+			}
+		}
+
 		const ref = await this.mapReference(documentContext.resolveReference(target, documentUri), isRawLink);
 
 		// Following [less-loader](https://github.com/webpack-contrib/less-loader#imports)

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -392,13 +392,6 @@ export class CSSNavigation {
 			return this.mapReference(await this.resolveModuleReference(target, documentUri, documentContext), isRawLink);
 		}
 
-		// Following the [sass package importer](https://github.com/sass/sass/blob/f6832f974c61e35c42ff08b3640ff155071a02dd/js-api-doc/importer.d.ts#L349),
-		// look for the `exports` field of the module and any `sass`, `style` or `default` that matches the import.
-		// If it's only `pkg:module`, also look for `sass` and `style` on the root of package.json.
-		if (target.startsWith('pkg:')) {
-			return this.resolvePkgModulePath(target, documentUri, documentContext);
-		}
-
 		const ref = await this.mapReference(documentContext.resolveReference(target, documentUri), isRawLink);
 
 		// Following [less-loader](https://github.com/webpack-contrib/less-loader#imports)
@@ -439,7 +432,7 @@ export class CSSNavigation {
 		return ref;
 	}
 
-	private async resolvePathToModule(_moduleName: string, documentFolderUri: string, rootFolderUri: string | undefined): Promise<string | undefined> {
+	protected async resolvePathToModule(_moduleName: string, documentFolderUri: string, rootFolderUri: string | undefined): Promise<string | undefined> {
 		// resolve the module relative to the document. We can't use `require` here as the code is webpacked.
 
 		const packPath = joinPath(documentFolderUri, 'node_modules', _moduleName, 'package.json');
@@ -451,89 +444,6 @@ export class CSSNavigation {
 		return undefined;
 	}
 
-	private async resolvePkgModulePath(target: string, documentUri: string, documentContext: DocumentContext): Promise<string | undefined> {
-		const bareTarget = target.replace('pkg:', '');
-		const moduleName = bareTarget.includes('/') ? getModuleNameFromPath(bareTarget) : bareTarget;
-		const rootFolderUri = documentContext.resolveReference('/', documentUri);
-		const documentFolderUri = dirname(documentUri);
-		const modulePath = await this.resolvePathToModule(moduleName, documentFolderUri, rootFolderUri);
-		if (modulePath) {
-			const packageJsonPath = `${modulePath}/package.json`;
-			if (packageJsonPath) {
-				// Since submodule exports import strings don't match the file system,
-				// we need the contents of `package.json` to look up the correct path.
-				let packageJsonContent = await this.getContent(packageJsonPath);
-				if (packageJsonContent) {
-					const packageJson: {
-						style?: string;
-						sass?: string;
-						exports: Record<string, string | Record<string, string>>
-					} = JSON.parse(packageJsonContent);
-
-					const subpath = bareTarget.substring(moduleName.length + 1);
-					if (packageJson.exports) {
-						if (!subpath) {
-							// look for the default/index export
-							// @ts-expect-error If ['.'] is a string this just produces undefined
-							const entry = packageJson.exports['.']['sass'] || packageJson.exports['.']['style'] || packageJson.exports['.']['default'];
-							// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-							if (entry && entry.endsWith('.scss')) {
-								const entryPath = joinPath(modulePath, entry);
-								return entryPath;
-							}
-						} else {
-							// The import string may be with or without .scss.
-							// Likewise the exports entry. Look up both paths.
-							// However, they need to be relative (start with ./).
-							const lookupSubpath = subpath.endsWith('.scss') ? `./${subpath.replace('.scss', '')}` : `./${subpath}`;
-							const lookupSubpathScss = subpath.endsWith('.scss') ? `./${subpath}` : `./${subpath}.scss`;
-							const subpathObject = packageJson.exports[lookupSubpathScss] || packageJson.exports[lookupSubpath];
-							if (subpathObject) {
-								// @ts-expect-error If subpathObject is a string this just produces undefined
-								const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
-								// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-								if (entry && entry.endsWith('.scss')) {
-									const entryPath = joinPath(modulePath, entry);
-									return entryPath;
-								}
-							} else {
-								// We have a subpath, but found no matches on direct lookup.
-								// It may be a [subpath pattern](https://nodejs.org/api/packages.html#subpath-patterns).
-								for (const [maybePattern, subpathObject] of Object.entries(packageJson.exports)) {
-									if (!maybePattern.includes("*")) {
-										continue;
-									}
-									// Patterns may also be without `.scss` on the left side, so compare without on both sides
-									const re = new RegExp(maybePattern.replace('./', '\\.\/').replace('.scss', '').replace('*', '(.+)'));
-									const match = re.exec(lookupSubpath);
-									if (match) {
-										// @ts-expect-error If subpathObject is a string this just produces undefined
-										const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
-										// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
-										if (entry && entry.endsWith('.scss')) {
-											// The right-hand side of a subpath pattern is also a pattern.
-											// Replace the pattern with the match from our regexp capture group above.
-											const expandedPattern = entry.replace('*', match[1]);
-											const entryPath = joinPath(modulePath, expandedPattern);
-											return entryPath;
-										}
-									}
-								}
-							}
-						}
-					} else if (!subpath && (packageJson.sass || packageJson.style)) {
-						// Fall back to a direct lookup on `sass` and `style` on package root
-						const entry = packageJson.sass || packageJson.style;
-						if (entry) {
-							const entryPath = joinPath(modulePath, entry);
-							return entryPath;
-						}
-					}
-				}
-			}
-		}
-		return undefined;
-	}
 
 	protected async fileExists(uri: string): Promise<boolean> {
 		if (!this.fileSystemProvider) {
@@ -633,7 +543,7 @@ function toTwoDigitHex(n: number): string {
 	return r.length !== 2 ? '0' + r : r;
 }
 
-function getModuleNameFromPath(path: string) {
+export function getModuleNameFromPath(path: string) {
 	const firstSlash = path.indexOf('/');
 	if (firstSlash === -1) {
 		return '';

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -460,6 +460,18 @@ export class CSSNavigation {
 		}
 	}
 
+	protected async getContent(uri: string): Promise<string | null> {
+		if (!this.fileSystemProvider || !this.fileSystemProvider.getContent) {
+			return null;
+		}
+		try {
+			return await this.fileSystemProvider.getContent(uri);
+		} catch (err) {
+			console.error(err);
+			return null;
+		}
+	}
+
 }
 
 function getColorInformation(node: nodes.Node, document: TextDocument): ColorInformation | null {

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -558,7 +558,6 @@ export class CSSNavigation {
 		try {
 			return await this.fileSystemProvider.getContent(uri);
 		} catch (err) {
-			console.error(err);
 			return null;
 		}
 	}

--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { CSSNavigation } from './cssNavigation';
+import { CSSNavigation, getModuleNameFromPath } from './cssNavigation';
 import { FileSystemProvider, DocumentContext, FileType, DocumentUri } from '../cssLanguageTypes';
 import * as nodes from '../parser/cssNodes';
 import { URI, Utils } from 'vscode-uri';
-import { startsWith } from '../utils/strings';
+import { convertSimple2RegExpPattern, startsWith } from '../utils/strings';
+import { dirname, joinPath } from '../utils/resources';
 
 export class SCSSNavigation extends CSSNavigation {
 	constructor(fileSystemProvider: FileSystemProvider | undefined) {
@@ -39,8 +40,106 @@ export class SCSSNavigation extends CSSNavigation {
 		if (startsWith(target, 'sass:')) {
 			return undefined; // sass library
 		}
+		// Following the [sass package importer](https://github.com/sass/sass/blob/f6832f974c61e35c42ff08b3640ff155071a02dd/js-api-doc/importer.d.ts#L349),
+		// look for the `exports` field of the module and any `sass`, `style` or `default` that matches the import.
+		// If it's only `pkg:module`, also look for `sass` and `style` on the root of package.json.
+		if (target.startsWith('pkg:')) {
+			return this.resolvePkgModulePath(target, documentUri, documentContext);
+		}
 		return super.resolveReference(target, documentUri, documentContext, isRawLink);
 	}
+
+	private async resolvePkgModulePath(target: string, documentUri: string, documentContext: DocumentContext): Promise<string | undefined> {
+		const bareTarget = target.replace('pkg:', '');
+		const moduleName = bareTarget.includes('/') ? getModuleNameFromPath(bareTarget) : bareTarget;
+		const rootFolderUri = documentContext.resolveReference('/', documentUri);
+		const documentFolderUri = dirname(documentUri);
+		const modulePath = await this.resolvePathToModule(moduleName, documentFolderUri, rootFolderUri);
+		if (!modulePath) {
+			return undefined;
+		}
+		// Since submodule exports import strings don't match the file system,
+		// we need the contents of `package.json` to look up the correct path.
+		let packageJsonContent = await this.getContent(joinPath(modulePath, 'package.json'));
+		if (!packageJsonContent) {
+			return undefined;
+		}
+		let packageJson: {
+			style?: string;
+			sass?: string;
+			exports?: Record<string, string | Record<string, string>>
+		};
+		try {
+			packageJson = JSON.parse(packageJsonContent);
+		} catch (e) {
+			// problems parsing package.json
+			return undefined;
+		}
+
+		const subpath = bareTarget.substring(moduleName.length + 1);
+		if (packageJson.exports) {
+			if (!subpath) {
+				const dotExport = packageJson.exports['.'];
+				// look for the default/index export
+				// @ts-expect-error If ['.'] is a string this just produces undefined
+				const entry = dotExport && (dotExport['sass'] || dotExport['style'] || dotExport['default']);
+				// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+				if (entry && entry.endsWith('.scss')) {
+					const entryPath = joinPath(modulePath, entry);
+					return entryPath;
+				}
+			} else {
+				// The import string may be with or without .scss.
+				// Likewise the exports entry. Look up both paths.
+				// However, they need to be relative (start with ./).
+				const lookupSubpath = subpath.endsWith('.scss') ? `./${subpath.replace('.scss', '')}` : `./${subpath}`;
+				const lookupSubpathScss = subpath.endsWith('.scss') ? `./${subpath}` : `./${subpath}.scss`;
+				const subpathObject = packageJson.exports[lookupSubpathScss] || packageJson.exports[lookupSubpath];
+				if (subpathObject) {
+					// @ts-expect-error If subpathObject is a string this just produces undefined
+					const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+					// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+					if (entry && entry.endsWith('.scss')) {
+						const entryPath = joinPath(modulePath, entry);
+						return entryPath;
+					}
+				} else {
+					// We have a subpath, but found no matches on direct lookup.
+					// It may be a [subpath pattern](https://nodejs.org/api/packages.html#subpath-patterns).
+					for (const [maybePattern, subpathObject] of Object.entries(packageJson.exports)) {
+						if (!maybePattern.includes("*")) {
+							continue;
+						}
+						// Patterns may also be without `.scss` on the left side, so compare without on both sides
+						const re = new RegExp(convertSimple2RegExpPattern(maybePattern.replace('.scss', '')).replace(/\.\*/g, '(.*)'));
+						const match = re.exec(lookupSubpath);
+						if (match) {
+							// @ts-expect-error If subpathObject is a string this just produces undefined
+							const entry = subpathObject['sass'] || subpathObject['styles'] || subpathObject['default'];
+							// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
+							if (entry && entry.endsWith('.scss')) {
+								// The right-hand side of a subpath pattern is also a pattern.
+								// Replace the pattern with the match from our regexp capture group above.
+								const expandedPattern = entry.replace('*', match[1]);
+								const entryPath = joinPath(modulePath, expandedPattern);
+								return entryPath;
+							}
+						}
+					}
+				}
+			}
+		} else if (!subpath && (packageJson.sass || packageJson.style)) {
+			// Fall back to a direct lookup on `sass` and `style` on package root
+			const entry = packageJson.sass || packageJson.style;
+			if (entry) {
+				const entryPath = joinPath(modulePath, entry);
+				return entryPath;
+			}
+		}
+		return undefined;
+
+	}
+
 }
 
 function toPathVariations(target: string): DocumentUri[] {

--- a/src/test/scss/scssNavigation.test.ts
+++ b/src/test/scss/scssNavigation.test.ts
@@ -32,7 +32,7 @@ async function assertDynamicLinks(docUri: string, input: string, expected: Docum
 	const ls = getSCSSLS();
 	if (settings) {
 		ls.configure(settings);
-	} 
+	}
 	const document = TextDocument.create(docUri, 'scss', 0, input);
 
 	const stylesheet = ls.parseStylesheet(document);
@@ -280,6 +280,51 @@ suite('SCSS - Navigation', () => {
 			);
 			await assertLinks(ls, '@import "green/e"',
 				[{ range: newRange(8, 17), target: getTestResource('node_modules/green/_e.scss') }], 'scss', testUri, workspaceFolder
+			);
+		});
+
+		test('SCSS node package resolving', async () => {
+			let ls = getSCSSLS();
+			let testUri = getTestResource('about.scss');
+			let workspaceFolder = getTestResource('');
+			await assertLinks(ls, `@use "pkg:bar"`,
+				[{ range: newRange(5, 14), target: getTestResource('node_modules/bar/styles/index.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:bar/colors"`,
+				[{ range: newRange(5, 21), target: getTestResource('node_modules/bar/styles/colors.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:bar/colors.scss"`,
+				[{ range: newRange(5, 26), target: getTestResource('node_modules/bar/styles/colors.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:@foo/baz"`,
+				[{ range: newRange(5, 19), target: getTestResource('node_modules/@foo/baz/styles/index.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:@foo/baz/colors"`,
+				[{ range: newRange(5, 26), target: getTestResource('node_modules/@foo/baz/styles/colors.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:@foo/baz/colors.scss"`,
+				[{ range: newRange(5, 31), target: getTestResource('node_modules/@foo/baz/styles/colors.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:@foo/baz/button"`,
+				[{ range: newRange(5, 26), target: getTestResource('node_modules/@foo/baz/styles/button.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:@foo/baz/button.scss"`,
+				[{ range: newRange(5, 31), target: getTestResource('node_modules/@foo/baz/styles/button.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:root-sass"`,
+				[{ range: newRange(5, 20), target: getTestResource('node_modules/root-sass/styles/index.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:root-style"`,
+				[{ range: newRange(5, 21), target: getTestResource('node_modules/root-style/styles/index.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:bar-pattern/anything"`,
+				[{ range: newRange(5, 31), target: getTestResource('node_modules/bar-pattern/styles/anything.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:bar-pattern/anything.scss"`,
+				[{ range: newRange(5, 36), target: getTestResource('node_modules/bar-pattern/styles/anything.scss')}], 'scss', testUri, workspaceFolder
+			);
+			await assertLinks(ls, `@use "pkg:bar-pattern/theme/dark.scss"`,
+				[{ range: newRange(5, 38), target: getTestResource('node_modules/bar-pattern/styles/theme/dark.scss')}], 'scss', testUri, workspaceFolder
 			);
 		});
 

--- a/src/test/testUtil/fsProvider.ts
+++ b/src/test/testUtil/fsProvider.ts
@@ -5,7 +5,7 @@
 
 import { FileSystemProvider, FileType } from "../../cssLanguageTypes";
 import { URI } from 'vscode-uri';
-import { stat as fsStat, readdir } from 'fs';
+import { stat as fsStat, readdir, readFile } from 'fs';
 
 export function getFsProvider(): FileSystemProvider {
 	return {
@@ -70,6 +70,21 @@ export function getFsProvider(): FileSystemProvider {
 							return [stat.name, FileType.Unknown];
 						}
 					}));
+				});
+			});
+		},
+		getContent(locationString, encoding = "utf-8") {
+			return new Promise((c, e) => {
+				const location = URI.parse(locationString);
+				if (location.scheme !== 'file') {
+					e(new Error('Protocol not supported: ' + location.scheme));
+					return;
+				}
+				readFile(location.fsPath, encoding, (err, data) => {
+					if (err) {
+						return e(err);
+					}
+					c(data);
 				});
 			});
 		}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -105,3 +105,8 @@ export function repeat(value: string, count: number) {
 	}
 	return s;
 }
+
+export function convertSimple2RegExpPattern(pattern: string): string {
+	return pattern.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&').replace(/[\*]/g, '.*');
+}
+

--- a/test/linksTestFixtures/node_modules/@foo/baz/package.json
+++ b/test/linksTestFixtures/node_modules/@foo/baz/package.json
@@ -1,0 +1,13 @@
+{
+  "exports": {
+    ".": {
+      "sass": "./styles/index.scss"
+    },
+    "./colors.scss": {
+      "sass": "./styles/colors.scss"
+    },
+    "./button": {
+      "sass": "./styles/button.scss"
+    }
+  }
+}

--- a/test/linksTestFixtures/node_modules/bar-pattern/package.json
+++ b/test/linksTestFixtures/node_modules/bar-pattern/package.json
@@ -1,0 +1,13 @@
+{
+  "exports": {
+    ".": {
+      "sass": "./styles/index.scss"
+    },
+    "./*.scss": {
+      "sass": "./styles/*.scss"
+    },
+    "./theme/*": {
+      "sass": "./styles/theme/*.scss"
+    }
+  }
+}

--- a/test/linksTestFixtures/node_modules/bar/package.json
+++ b/test/linksTestFixtures/node_modules/bar/package.json
@@ -1,0 +1,13 @@
+{
+  "exports": {
+    ".": {
+      "sass": "./styles/index.scss"
+    },
+    "./colors.scss": {
+      "sass": "./styles/colors.scss"
+    },
+    "./button": {
+      "sass": "./styles/button.scss"
+    }
+  }
+}

--- a/test/linksTestFixtures/node_modules/root-sass/package.json
+++ b/test/linksTestFixtures/node_modules/root-sass/package.json
@@ -1,0 +1,3 @@
+{
+  "sass": "./styles/index.scss"
+}

--- a/test/linksTestFixtures/node_modules/root-style/package.json
+++ b/test/linksTestFixtures/node_modules/root-style/package.json
@@ -1,0 +1,3 @@
+{
+  "style": "./styles/index.scss"
+}


### PR DESCRIPTION
Fixes #383

Hello 👋 I'm opening a PR with a suggested solution for #383

As mentioned in the issue, Sass released a [new syntax for import strings](https://sass-lang.com/blog/announcing-pkg-importers/), which I imagine trips up a lot of tools. I find the documentation for [NodePackageImporter](https://github.com/sass/sass/blob/f6832f974c61e35c42ff08b3640ff155071a02dd/js-api-doc/importer.d.ts#L349) has the most readable explanation of the different supported scenarios. Also relevant here is the Node documentation on [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns).

It's a big chunk with many different code paths, I'll admit. I've tried documenting at a reasonable level, and added tests that should cover a lot of scenarios. That said, I understand if you're hesitant to add yet more module resolution logic here.

I've tested locally with `npm link` in a [running extension using these test fixtures](https://github.com/wkillerud/vscode-scss/commit/86e7be3c73847fd7a983c0f69837124eb5bb9407), and the resolution provides correct links for me. Recording of that below.

https://github.com/microsoft/vscode-css-languageservice/assets/1223410/37020935-38a8-4706-9c36-b07a34e7f166

## Considered alternatives

Sass's JavaScript API includes the aforementioned [NodePackageImporter](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/). Its implementation seems to have a function [`canonicalize`](https://github.com/sass/dart-sass/blob/3e6721e79f049dd01880542667380640c2d1eeae/lib/src/importer/node_package.dart#L37), which looked promising as a method of looking up an import string. Unfortunately it's not part of the public API.

The result from `sass.compile` includes all the loaded URLs, so I'm sure you could hack something together there (pass in a string that only `@use`s the `pkg:module` import in question). It would require bundling `sass` though, which is also [technically possible](https://sass-lang.com/blog/sass-in-the-browser/) now.