### PR TITLE
fix: support for conditional exports in sass's pkg

### DIFF
--- a/src/services/scssNavigation.ts
+++ b/src/services/scssNavigation.ts
@@ -79,10 +79,11 @@ export class SCSSNavigation extends CSSNavigation {
 		const subpath = bareTarget.substring(moduleName.length + 1);
 		if (packageJson.exports) {
 			if (!subpath) {
-				const dotExport = packageJson.exports['.'];
+				// exports may look like { "sass": "./_index.scss" } or { ".": { "sass": "./_index.scss" } }
+				const rootExport = packageJson.exports["."] || packageJson.exports;
 				// look for the default/index export
 				// @ts-expect-error If ['.'] is a string this just produces undefined
-				const entry = dotExport && (dotExport['sass'] || dotExport['style'] || dotExport['default']);
+				const entry = rootExport && (rootExport['sass'] || rootExport['style'] || rootExport['default']);
 				// the 'default' entry can be whatever, typically .js – confirm it looks like `scss`
 				if (entry && entry.endsWith('.scss')) {
 					const entryPath = joinPath(modulePath, entry);

--- a/src/test/scss/scssNavigation.test.ts
+++ b/src/test/scss/scssNavigation.test.ts
@@ -326,6 +326,9 @@ suite('SCSS - Navigation', () => {
 			await assertLinks(ls, `@use "pkg:bar-pattern/theme/dark.scss"`,
 				[{ range: newRange(5, 38), target: getTestResource('node_modules/bar-pattern/styles/theme/dark.scss')}], 'scss', testUri, workspaceFolder
 			);
+			await assertLinks(ls, `@use "pkg:conditional"`,
+				[{ range: newRange(5, 22), target: getTestResource('node_modules/conditional/_index.scss')}], 'scss', testUri, workspaceFolder
+			);
 		});
 
 	});

--- a/test/linksTestFixtures/node_modules/conditional/package.json
+++ b/test/linksTestFixtures/node_modules/conditional/package.json
@@ -1,0 +1,6 @@
+{
+  "exports": {
+    "sass": "./_index.scss",
+    "default": "./index.js"
+  }
+}


### PR DESCRIPTION
Hello, and thanks for landing the support for `pkg:` imports in Sass ❤️ 

I was made aware in https://github.com/wkillerud/some-sass/issues/184 that the link resolution doesn't work as expected for the `sass-true` package. Turns out there was a variant of `"exports"` I didn't handle in the initial PR.

- [`sass-true`'s `package.json`](https://github.com/oddbird/true/blob/main/package.json#L99)
- Node: [Conditional Exports](https://nodejs.org/api/packages.html#conditional-exports)

This PR adds a test case for this format of `"exports"` and updates the "dotExport" to be "rootExport", handling this as a fallback if no `"exports": { ".": /* ... */ }` exists.