### PR TITLE
feature:(#305) Add support for `oklab` and `oklch` color functions

### DIFF
--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -11,7 +11,15 @@ import {
 import * as l10n from '@vscode/l10n';
 import * as nodes from '../parser/cssNodes';
 import { Symbols } from '../parser/cssSymbolScope';
-import { getColorValue, hslFromColor, hwbFromColor, labFromColor, lchFromColor } from '../languageFacts/facts';
+import {
+	getColorValue,
+	hslFromColor,
+	hwbFromColor,
+	labFromColor,
+	lchFromColor,
+	oklabFromColor,
+	oklchFromColor,
+} from '../languageFacts/facts';
 import { startsWith } from '../utils/strings';
 import { dirname, joinPath } from '../utils/resources';
 
@@ -352,12 +360,21 @@ export class CSSNavigation {
 		result.push({ label: label, textEdit: TextEdit.replace(range, label) });
 
 		const lch = lchFromColor(color);
-		if (lab.alpha === 1) {
+		if (lch.alpha === 1) {
 			label = `lch(${lch.l}% ${lch.c} ${lch.h})`;
 		} else {
 			label = `lch(${lch.l}% ${lch.c} ${lch.h} / ${lch.alpha})`;
 		}
 		result.push({ label: label, textEdit: TextEdit.replace(range, label) });
+
+		const oklab = oklabFromColor(color);
+		label = (oklab.alpha === 1) ? `oklab(${oklab.l}% ${oklab.a} ${oklab.b})` : `oklab(${oklab.l}% ${oklab.a} ${oklab.b} / ${oklab.alpha})`;
+		result.push({ label: label, textEdit: TextEdit.replace(range, label) });
+
+		const oklch = oklchFromColor(color);
+		label = (oklch.alpha === 1) ? `oklch(${oklch.l}% ${oklch.c} ${oklch.h})` : `oklch(${oklch.l}% ${oklch.c} ${oklch.h} / ${oklch.alpha})`;
+		result.push({ label: label, textEdit: TextEdit.replace(range, label) });
+
 		return result;
 	}
 

--- a/src/test/css/languageFacts.test.ts
+++ b/src/test/css/languageFacts.test.ts
@@ -5,7 +5,38 @@
 'use strict';
 
 import * as assert from 'assert';
-import { isColorValue, getColorValue, colorFrom256RGB, colorFromHex, hexDigit, hslFromColor, HSLA, XYZ, LAB, xyzToRGB, xyzFromLAB, hwbFromColor, HWBA, colorFromHWB, colorFromHSL, colorFromLAB, labFromLCH, colorFromLCH, labFromColor, RGBtoXYZ, lchFromColor, LCH, getMissingBaselineBrowsers } from '../../languageFacts/facts';
+import {
+    colorFrom256RGB,
+    colorFromHex,
+    colorFromHSL,
+    colorFromHWB,
+    colorFromLAB,
+    colorFromLCH,
+    colorFromOKLAB,
+    colorFromOKLCH,
+    getColorValue,
+    getMissingBaselineBrowsers,
+    hexDigit,
+    hslFromColor,
+    hwbFromColor,
+    isColorValue,
+    labFromColor,
+    labFromLCH,
+    lchFromColor,
+    oklabFromColor,
+    RGBtoXYZ,
+    xyzFromLAB,
+    xyzFromOKLAB,
+    XYZtoOKLAB,
+    xyzToRGB,
+} from '../../languageFacts/facts';
+import type {
+    HSLA,
+    HWBA,
+    LAB,
+    LCH,
+    XYZ,
+} from '../../languageFacts/facts';
 import { Parser } from '../../parser/cssParser';
 import * as nodes from '../../parser/cssNodes';
 import { TextDocument, Color } from '../../cssLanguageTypes';
@@ -141,7 +172,7 @@ suite('CSS - Language Facts', () => {
 	});
 
 	test('is color', function () {
-		let parser = new Parser();
+		const parser = new Parser();
 		assertColor(parser, '#main { color: red }', 'red', colorFrom256RGB(0xFF, 0, 0));
 		assertColor(parser, '#main { color: slateblue }', 'slateblue', colorFrom256RGB(106, 90, 205));
 		assertColor(parser, '#main { color: #231 }', '#231', colorFrom256RGB(0x22, 0x33, 0x11));
@@ -177,6 +208,13 @@ suite('CSS - Language Facts', () => {
 		assertColor(parser, '#main { color: lab(46.41 39.24 33.51) }', 'lab', colorFrom256RGB(180, 79, 56));
 		assertColor(parser, '#main { color: lab(46.41 -39.24 33.51) }', 'lab', colorFrom256RGB(50, 125, 50));
 		assertColor(parser, '#main { color: lch(46.41, 51.60, 139.50) }', 'lch', colorFrom256RGB(50, 125, 50));
+		assertColor(parser, '#main { color: oklab(62.8% 56.25% 31.5%) }', 'oklab', colorFrom256RGB(255, 0, 0));
+		assertColor(parser, '#main { color: oklab(62.796% 0.22486 0.12585) }', 'oklab', colorFrom256RGB(255, 0, 0));
+		assertColor(parser, '#main { color: oklab(.53376 .13032 -.21371) }', 'oklab', colorFrom256RGB(138, 43, 226));
+		assertColor(parser, '#main { color: oklch(62.7955% 0.257683 29.2339) }', 'oklch', colorFrom256RGB(255, 0, 0));
+		assertColor(parser, '#main { color: oklch(0.70167 0.32249 328.36deg) }', 'oklch', colorFrom256RGB(255, 0, 255));
+		assertColor(parser, '#main { color: oklch(.8241 26.5225% 0.84891) }', 'oklch', colorFrom256RGB(255, 168, 193));
+		assertColor(parser, '#main { color: oklch(0% 0 none) }', 'oklch', colorFrom256RGB(0, 0, 0));
 	});
 
 	test('hexDigit', function () {
@@ -286,6 +324,13 @@ suite('CSS - Language Facts', () => {
 		assertXYZValue(xyzFromLAB({ l: 90, a: 50, b: -50 }), { x: 99.03, y: 76.3, z: 171.63, alpha: 1 });
 	});
 
+	test('xyzFromOKLAB', function () {
+	    // Verified with https://www.colorspaceconverter.com/converter/oklab-to-xyz
+	    assertXYZValue(xyzFromOKLAB({ l: 0.52, a: -0.11, b: 0.08 }), { x: 8.8, y: 15.19, z: 5.24, alpha: 1 });
+	    assertXYZValue(xyzFromOKLAB({ l: 0.55, a: -0.14, b: 0.11 }), { x: 9.49, y: 18.2, z: 3.42, alpha: 1 });
+	    assertXYZValue(xyzFromOKLAB({ l: 0.86, a: 0.08, b: -0.01 }), { x: 70.1, y: 61.33, z: 71.52, alpha: 1 });
+	});
+
 	test('xyzToRGB', function () {
 		// verified with https://www.colorspaceconverter.com/converter/xyz-to-rgb
 		assertColorValue(xyzToRGB({ x: 9.22, y: 15.58, z: 5.54, alpha: 1 }), { red: 50, green: 125, blue: 50, alpha: 1 }, 'xyz(9.22, 15.58, 5.54)');
@@ -293,18 +338,43 @@ suite('CSS - Language Facts', () => {
 		assertColorValue(xyzToRGB({ x: 99, y: 76, z: 71, alpha: 1 }), { red: 255, green: 187, blue: 211, alpha: 1 }, '3');
 
 	});
+
+	test('XYZtoOKLAB', function () {
+	    // Verified with https://www.colorspaceconverter.com/converter/oklab-to-xyz
+	    assertLABValue(XYZtoOKLAB({ x: 8.8, y: 15.19, z: 5.24, alpha: 1 }), { l: 0.52, a: -0.110_09, b: 0.079_98, alpha: 1 });
+	    assertLABValue(XYZtoOKLAB({ x: 9.49, y: 18.2, z: 3.42, alpha: 1 }), { l: 0.549_98, a: -0.14, b: 0.109_94, alpha: 1 });
+	    assertLABValue(XYZtoOKLAB({ x: 70.1, y: 61.33, z: 71.52, alpha: 1 }), { l: 0.860_01, a: 0.079_99, b: -0.010_11, alpha: 1 });
+	});
+
 	test('LABToRGB', function () {
 		assertColorValue(colorFromLAB(46.41, -39.24, 33.51), colorFrom256RGB(50, 125, 50), 'lab(46.41, -39.24, 33.51)');
 	});
+
+	test('OKLABToRGB', function () {
+	    // Verified with https://www.colorspaceconverter.com/converter/oklab-to-rgb
+	    assertColorValue(colorFromOKLAB(0.86, 0.08, -0.01), colorFrom256RGB(251.88, 187.65, 213.63), 'oklab(86%, 0.08, -0.01)');
+	});
+
 	test('labFromLCH', function () {
 		assertLABValue(labFromLCH(46.41, 51.60, 139.50), { l: 46.41, a: -39.24, b: 33.51, alpha: 1 });
 	});
 	test('LCHtoRGB', function () {
 		assertColorValue(colorFromLCH(46.41, 51.60, 139.50), colorFrom256RGB(50, 125, 50), 'lch(46.41, 51.60, 139.50)');
 	});
+
+	test('OKLCHtoRGB', function () {
+	    // Verified with https://www.colorspaceconverter.com/converter/oklch-to-rgb
+	    assertColorValue(colorFromOKLCH(0.52, 0.13, 143.39), colorFrom256RGB(50.32, 123.2, 50.17), 'oklch(52%, .13, 143.39)');
+	});
+
 	test('labFromColor', function () {
 		assertLABValue(labFromColor(colorFrom256RGB(50, 125, 50)), { l: 46.41, a: -39.24, b: 33.51, alpha: 1 });
 	});
+
+	test('oklabFromColor', function () {
+	    assertLABValue(oklabFromColor(colorFrom256RGB(50, 125, 50)), { l: 52.488, a: -0.106_65, b: 0.079_16, alpha: 1 });
+	});
+
 	test('RGBToXYZ', function () {
 		assertXYZValue(RGBtoXYZ(colorFrom256RGB(50, 125, 50)), { x: 9.22, y: 15.58, z: 5.54, alpha: 1 });
 	});

--- a/src/test/css/navigation.test.ts
+++ b/src/test/css/navigation.test.ts
@@ -479,9 +479,31 @@ suite('CSS - Navigation', () => {
 		});
 
 		test('color presentations', function () {
-			let ls = getCSSLS();
-			assertColorPresentations(ls, colorFrom256RGB(255, 0, 0), 'rgb(255, 0, 0)', '#ff0000', 'hsl(0, 100%, 50%)', 'hwb(0 0% 0%)', 'lab(53.23% 80.11 67.22)', 'lch(53.23% 104.58 40)');
-			assertColorPresentations(ls, colorFrom256RGB(77, 33, 111, 0.5), 'rgba(77, 33, 111, 0.5)', '#4d216f80', 'hsla(274, 54%, 28%, 0.5)', 'hwb(274 13% 56% / 0.5)', 'lab(23.04% 35.9 -36.96 / 0.5)', 'lch(23.04% 51.53 314.16 / 0.5)');
+			const ls = getCSSLS();
+			assertColorPresentations(
+				ls,
+				colorFrom256RGB(255, 0, 0),
+				'rgb(255, 0, 0)',
+				'#ff0000',
+				'hsl(0, 100%, 50%)',
+				'hwb(0 0% 0%)',
+				'lab(53.23% 80.11 67.22)',
+				'lch(53.23% 104.58 40)',
+				'oklab(62.793% 0.22489 0.1258)',
+				'oklch(62.793% 0.25768 29.223)',
+			);
+			assertColorPresentations(
+				ls,
+				colorFrom256RGB(77, 33, 111, 0.5),
+				'rgba(77, 33, 111, 0.5)',
+				'#4d216f80',
+				'hsla(274, 54%, 28%, 0.5)',
+				'hwb(274 13% 56% / 0.5)',
+				'lab(23.04% 35.9 -36.96 / 0.5)',
+				'lch(23.04% 51.53 314.16 / 0.5)',
+				'oklab(35.231% 0.0782 -0.10478 / 0.5)',
+				'oklch(35.231% 0.13074 306.734 / 0.5)',
+			);
 		});
 	});
 });


### PR DESCRIPTION
__RESOLVES:__
_feature_ - *Add new CSS color functions* \[[#305](https://github.com/microsoft/vscode-css-languageservice/issues/305)\]

__DESCRIPTION:__
CSS Color Module Level 4 adds support for `oklch` and `oklab` to browsers. They are becoming more popular, and I wanted to use them with color previews in my editor.

This feature is built off of the original [#306](https://github.com/microsoft/vscode-css-languageservice/pull/306) which included steps for `lab` and `lch` but not the `ok` variants.

Generally this code was designed using real world color [examples](https://www.oddcontrast.com/#hex__*f00__*4d216f80__srgb).

__STEPS TO TEST:__

Tests were added to relevant files following established patterns. Should be able to just run `npm run test`. However I don't use vscode, so I did not test in an actual editor.