### PR TITLE
refactor: Extend the base tsconfig.json

### DIFF
--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -1,15 +1,7 @@
 {
+	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"target": "es2020",
 		"module": "es6",
-		"moduleResolution": "node",
-		"sourceMap": true,
-		"declaration": true,
-		"strict": true,
-		"stripInternal": true,
-		"outDir": "../lib/esm",
-		"lib": [
-			"es2020"
-		]
+		"outDir": "../lib/esm"
 	}
 }


### PR DESCRIPTION
__DESCRIPTION:__
I noticed that both the `tsconfig.json` and the `tsconfig.esm.json` files are largely the same. So it makes sense to me to extend the base on instead of duplicating the configuration options.