### PR TITLE
css: resolve bare module specifiers in @import to node_modules

### DIFF
--- a/src/cssLanguageService.ts
+++ b/src/cssLanguageService.ts
@@ -116,7 +116,7 @@ export function getCSSLanguageService(options: LanguageServiceOptions = defaultL
 		new Parser(),
 		new CSSCompletion(null, options, cssDataManager),
 		new CSSHover(options && options.clientCapabilities, cssDataManager),
-		new CSSNavigation(options && options.fileSystemProvider, false),
+		new CSSNavigation(options && options.fileSystemProvider, true),
 		new CSSCodeActions(cssDataManager),
 		new CSSValidation(cssDataManager),
 		cssDataManager

--- a/src/services/cssNavigation.ts
+++ b/src/services/cssNavigation.ts
@@ -593,7 +593,7 @@ function toTwoDigitHex(n: number): string {
 export function getModuleNameFromPath(path: string) {
 	const firstSlash = path.indexOf('/');
 	if (firstSlash === -1) {
-		return '';
+		return path;
 	}
 
 	// If a scoped module (starts with @) then get up until second instance of '/', or to the end of the string for root-level imports.

--- a/src/test/css/navigation.test.ts
+++ b/src/test/css/navigation.test.ts
@@ -460,6 +460,16 @@ suite('CSS - Navigation', () => {
 				[{ range: newRange(8, 24), target: getTestResource('green/c.css') }], 'css', testUri, workspaceFolder
 			);
 		});
+
+		test('bare module specifier resolving', async function () {
+			const ls = getCSSLS();
+			const testUri = getTestResource('about.css');
+			const workspaceFolder = getTestResource('');
+
+			await assertLinks(ls, '@import "foo/bar.css"',
+				[{ range: newRange(8, 21), target: getTestResource('node_modules/foo/bar.css') }], 'css', testUri, workspaceFolder
+			);
+		});
 	});
 
 	suite('Color', () => {

--- a/test/linksTestFixtures/node_modules/foo/bar.css
+++ b/test/linksTestFixtures/node_modules/foo/bar.css
@@ -1,0 +1,1 @@
+/* test fixture */


### PR DESCRIPTION
Fixes microsoft/vscode#295074

## Summary

CSS `@import` statements with bare module specifiers (e.g. `@import "foo/bar.css"`) currently do not resolve to `node_modules`, even though SCSS and LESS already support this. This PR fixes two issues:

1. **Enable `resolveModuleReferences` for CSS** — the node_modules fallback path was disabled for CSS (`false`) while SCSS and LESS both had it enabled (`true`). This aligns CSS with the existing behavior.

2. **Fix `getModuleNameFromPath()` for bare specifiers** — the function returned an empty string for module names without a slash (e.g. `"bootstrap"`), causing resolution to silently fail. It now returns the full path as the module name.

This was originally attempted in [microsoft/vscode#305900](https://github.com/microsoft/vscode/pull/305900) at the `getDocumentContext` level, but @aeschli [pointed out](https://github.com/microsoft/vscode/pull/305900#issuecomment-4153145509) it belongs here in the language service.

## Changes

| File | Change |
|------|--------|
| `src/cssLanguageService.ts` | Set `resolveModuleReferences: true` for `getCSSLanguageService()` |
| `src/services/cssNavigation.ts` | Return full path from `getModuleNameFromPath()` when no slash present |
| `src/test/css/navigation.test.ts` | Add test for bare module specifier resolution |
| `test/linksTestFixtures/node_modules/foo/bar.css` | Test fixture |

## Test plan

- [x] All 709 existing tests pass
- [x] New test: `@import "foo/bar.css"` resolves to `node_modules/foo/bar.css`
- [x] Existing tilde-prefix resolution (`~foo/hello.html`) continues to work
- [x] Local file resolution takes precedence over node_modules fallback