### PR TITLE
Support container scroll-state queries

### DIFF
--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -1472,19 +1472,33 @@ export class Parser {
 		const node = this.create(nodes.Container);
 		this.consumeToken(); // @container
 
-		node.addChild(this._parseIdent()); // optional container name
+		node.addChild(this._parseContainerName()); // optional container name
 		if (node.addChild(this._parseContainerQuery())) {
 			while (this.accept(TokenType.Comma)) {
 				if (this.peek(TokenType.CurlyL)) {
 					break;
 				}
 
-				node.addChild(this._parseIdent()); // optional container name
+				node.addChild(this._parseContainerName()); // optional container name
 				node.addChild(this._parseContainerQuery());
 			}
 		}
 
 		return this._parseBody(node, this._parseContainerDeclaration.bind(this, isNested));
+	}
+
+	public _parseContainerName(): nodes.Node | null {
+		if (this.peekIdent('style') || this.peekIdent('scroll-state')) {
+			const mark = this.mark();
+			this.consumeToken();
+			if (!this.hasWhitespace() && this.peek(TokenType.ParenthesisL)) {
+				this.restoreAtMark(mark);
+				return null;
+			}
+			this.restoreAtMark(mark);
+		}
+
+		return this._parseIdent();
 	}
 
 	public _parseContainerQuery(): nodes.Node | null {
@@ -1512,6 +1526,7 @@ export class Parser {
 		// <query-in-parens>     = ( <container-query> )
 		// 					  | ( <size-feature> )
 		// 					  | style( <style-query> )
+		// 					  | scroll-state( <scroll-state-query> )
 		// 					  | <general-enclosed>
 		const node = this.create(nodes.Node);
 		if (this.accept(TokenType.ParenthesisL)) {
@@ -1528,6 +1543,14 @@ export class Parser {
 				return this.finish(node, ParseError.LeftParenthesisExpected, [], [TokenType.CurlyL]);
 			}
 			node.addChild(this._parseStyleQuery());
+			if (!this.accept(TokenType.ParenthesisR)) {
+				return this.finish(node, ParseError.RightParenthesisExpected, [], [TokenType.CurlyL]);
+			}
+		} else if (this.acceptIdent('scroll-state')) {
+			if (this.hasWhitespace() || !this.accept(TokenType.ParenthesisL)) {
+				return this.finish(node, ParseError.LeftParenthesisExpected, [], [TokenType.CurlyL]);
+			}
+			node.addChild(this._parseDeclaration([TokenType.ParenthesisR], true));
 			if (!this.accept(TokenType.ParenthesisR)) {
 				return this.finish(node, ParseError.RightParenthesisExpected, [], [TokenType.CurlyL]);
 			}

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -187,6 +187,10 @@ suite('CSS - Parser', () => {
 		assertNode(`@container card (inline-size > 30em), style(--responsive: true) { }`, parser, parser._parseStylesheet.bind(parser));
 		assertNode(`@container card (inline-size > 30em), summary style(--responsive: true) { }`, parser, parser._parseStylesheet.bind(parser));
 		assertNode(`@container card (inline-size > 30em) { @container style(--responsive: true) {} }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@media (pointer: fine) and (hover: hover) { @container my-container scroll-state(scrollable: y) { #my-list { padding-inline-end: calc(var(--spacing) * 2); } } }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@container scroll-state(scrollable: y) { }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@container my-container scroll-state(scrollable: y) and style(--responsive: true) { }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@container card (inline-size > 30em), my-container scroll-state(stuck: top) { }`, parser, parser._parseStylesheet.bind(parser));
 	});
 
 	test('@starting-style', function () {

--- a/src/test/less/parser.test.ts
+++ b/src/test/less/parser.test.ts
@@ -354,5 +354,6 @@ suite('LESS - Parser', () => {
 		const parser = new LESSParser();
 		assertNode(`.item-icon { @container (max-height: 100px) { .item-icon { display: none;  } } }`, parser, parser._parseStylesheet.bind(parser));
 		assertNode(`:root { @container (max-height: 100px) { display: none;} }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@container my-container scroll-state(scrollable: y) { .item-icon { display: none; } }`, parser, parser._parseStylesheet.bind(parser));
 	});
 });

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -294,6 +294,7 @@ suite('SCSS - Parser', () => {
 		assertNode(`@container (min-width: #{$minWidth}) { .scss-interpolation { line-height: 10cqh; } }`, parser, parser._parseStylesheet.bind(parser));
 		assertNode(`.item-icon { @container (max-height: 100px) { .item-icon { display: none;  } } }`, parser, parser._parseStylesheet.bind(parser));
 		assertNode(`:root { @container (max-height: 100px) { display: none;} }`, parser, parser._parseStylesheet.bind(parser));
+		assertNode(`@container my-container scroll-state(scrollable: y) { .item-icon { display: none; } }`, parser, parser._parseStylesheet.bind(parser));
 	});
 
 	test('@use', function () {


### PR DESCRIPTION
Closes #454

## Summary

CSS container scroll-state queries such as `@container my-container scroll-state(scrollable: y)` are valid syntax, but the parser currently treats `scroll-state` as invalid unless the query starts with a parenthesised size query or `style(...)`.

This PR adds parser support for `scroll-state(...)` container queries while keeping the change focused to the existing `@container` query parsing path.

This is my first pull request here, so I followed the format of #485.

## Changes

| File | Change |
|------|--------|
| `src/parser/cssParser.ts` | Recognise `scroll-state(...)` as a valid container query form |
| `src/parser/cssParser.ts` | Avoid consuming function-style query names like `scroll-state(...)` as container names |
| `src/test/css/parser.test.ts` | Add coverage for named, unnamed, nested, compound, and comma-list scroll-state queries |
| `src/test/scss/parser.test.ts` | Add SCSS parser coverage |
| `src/test/less/parser.test.ts` | Add LESS parser coverage |

## Test plan

- [x] Full test suite passes with `npm run test`
- [x] New test: reported `@media` + named `@container ... scroll-state(scrollable: y)` syntax parses without diagnostics
- [x] New test: unnamed `@container scroll-state(scrollable: y)` parses without treating `scroll-state` as a container name
- [x] Existing `style(...)`, size-query, nested container, SCSS, and LESS parser behaviour continues to pass