### PR TITLE
Support the modern attr() type() syntax

### DIFF
--- a/src/parser/cssParser.ts
+++ b/src/parser/cssParser.ts
@@ -29,6 +29,9 @@ export class Parser {
 
 	private lastErrorToken?: IToken;
 
+	// Tracks nesting inside `attr()`, where `type(<syntax>)` is a valid argument.
+	protected attrDepth: number = 0;
+
 	constructor(scnr: Scanner = new Scanner()) {
 		this.scanner = scnr;
 		this.token = { type: TokenType.EOF, offset: -1, len: 0, text: '' };
@@ -2049,6 +2052,7 @@ export class Parser {
 	public _parseTermExpression(): nodes.Node | null {
 		return this._parseURILiteral() || // url before function
 			this._parseUnicodeRange() ||
+			this._parseAttrType() || // type(<syntax>) inside attr(), before the generic function
 			this._parseFunction() || // function before ident
 			this._parseIdent() ||
 			this._parseStringLiteral() ||
@@ -2155,6 +2159,7 @@ export class Parser {
 			parseArgument = this._parseIfBranch.bind(this);
 			separator = TokenType.SemiColon;
 		}
+		const isAttr = this.peekIdent("attr");
 
 		if (!node.setIdentifier(this._parseFunctionIdentifier())) {
 			return null;
@@ -2165,6 +2170,9 @@ export class Parser {
 			return null;
 		}
 
+		if (isAttr) {
+			this.attrDepth++;
+		}
 		if (node.getArguments().addChild(parseArgument())) {
 			while (this.accept(separator)) {
 				if (this.peek(TokenType.ParenthesisR)) {
@@ -2174,6 +2182,9 @@ export class Parser {
 					this.markError(node, ParseError.ExpressionExpected);
 				}
 			}
+		}
+		if (isAttr) {
+			this.attrDepth--;
 		}
 
 		if (!this.accept(TokenType.ParenthesisR)) {
@@ -2209,6 +2220,67 @@ export class Parser {
 			return this.finish(node);
 		}
 		return null;
+	}
+
+	public _parseAttrType(): nodes.Node | null {
+		// The modern `attr()` accepts a type as `type( <syntax> )`, e.g. `attr(data-x type(<length>))`.
+		// This is only valid inside `attr()`, so it is guarded by attrDepth to avoid shadowing a
+		// user-defined `type()` function (e.g. a Sass `@function type()`) elsewhere.
+		// https://drafts.csswg.org/css-values-5/#attr-notation
+		if (this.attrDepth === 0 || !this.peekIdent('type')) {
+			return null;
+		}
+
+		const pos = this.mark();
+		const node = this.create(nodes.Function);
+		node.setIdentifier(this._parseFunctionIdentifier());
+
+		if (this.hasWhitespace() || !this.accept(TokenType.ParenthesisL)) {
+			this.restoreAtMark(pos);
+			return null;
+		}
+
+		if (!node.getArguments().addChild(this._parseAttrTypeSyntax())) {
+			return this.finish(node, ParseError.ExpressionExpected, [], [TokenType.ParenthesisR]);
+		}
+
+		if (!this.accept(TokenType.ParenthesisR)) {
+			return this.finish(node, ParseError.RightParenthesisExpected);
+		}
+		return this.finish(node);
+	}
+
+	public _parseAttrTypeSyntax(): nodes.Node | null {
+		// <syntax> = '*' | <syntax-component> [ '|' <syntax-component> ]*
+		const node = this.create(nodes.Node);
+		if (this.acceptDelim('*')) {
+			return this.finish(node);
+		}
+		if (!this._acceptAttrSyntaxComponent()) {
+			return null;
+		}
+		while (this.acceptDelim('|')) {
+			if (!this._acceptAttrSyntaxComponent()) {
+				return this.finish(node, ParseError.IdentifierExpected);
+			}
+		}
+		return this.finish(node);
+	}
+
+	private _acceptAttrSyntaxComponent(): boolean {
+		// <syntax-component> = ( '<' <syntax-type-name> '>' | <ident> ) <syntax-multiplier>?
+		if (this.acceptDelim('<')) {
+			if (!this.accept(TokenType.Ident) || !this.acceptDelim('>')) {
+				return false;
+			}
+		} else if (!this.accept(TokenType.Ident)) {
+			return false;
+		}
+		// optional multiplier: '+' or '#'
+		if (!this.acceptDelim('+')) {
+			this.acceptDelim('#');
+		}
+		return true;
 	}
 
 	public _parseIfBranch() {

--- a/src/parser/lessParser.ts
+++ b/src/parser/lessParser.ts
@@ -769,6 +769,8 @@ export class LESSParser extends cssParser.Parser {
 		const pos = this.mark();
 		const node = <nodes.Function>this.create(nodes.Function);
 
+		const isAttr = this.peekIdent("attr");
+
 		if (!node.setIdentifier(this._parseFunctionIdentifier())) {
 			return null;
 		}
@@ -778,15 +780,24 @@ export class LESSParser extends cssParser.Parser {
 			return null;
 		}
 
+		if (isAttr) {
+			this.attrDepth++;
+		}
 		if (node.getArguments().addChild(this._parseMixinArgument())) {
 			while (this.accept(TokenType.Comma) || this.accept(TokenType.SemiColon)) {
 				if (this.peek(TokenType.ParenthesisR)) {
 					break;
 				}
 				if (!node.getArguments().addChild(this._parseMixinArgument())) {
+					if (isAttr) {
+						this.attrDepth--;
+					}
 					return this.finish(node, ParseError.ExpressionExpected);
 				}
 			}
+		}
+		if (isAttr) {
+			this.attrDepth--;
 		}
 
 		if (!this.accept(TokenType.ParenthesisR)) {

--- a/src/test/css/parser.test.ts
+++ b/src/test/css/parser.test.ts
@@ -644,6 +644,27 @@ suite('CSS - Parser', () => {
 		assertError('if(invalid: black;)', parser, parser._parseFunction.bind(parser), ParseError.IfConditionExpected);
 	});
 
+	test('attr', function () {
+		const parser = new Parser();
+		// legacy forms keep working
+		assertFunction('attr(data-x)', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x, "fallback")', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x px)', parser, parser._parseFunction.bind(parser));
+		// modern attr() type() syntax (https://drafts.csswg.org/css-values-5/#attr-notation)
+		assertFunction('attr(data-x type(<length>))', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x type(<length>), 0px)', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x type(*))', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x type(<length> | <percentage>))', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x type(<custom-ident>#))', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x type(<length>+))', parser, parser._parseFunction.bind(parser));
+		assertFunction('attr(data-x raw-string)', parser, parser._parseFunction.bind(parser));
+		// type() is only special inside attr(): elsewhere it is a normal function reference
+		assertFunction('type(foo)', parser, parser._parseFunction.bind(parser));
+		// malformed type() still reports an error
+		assertError('attr(data-x type())', parser, parser._parseFunction.bind(parser), ParseError.ExpressionExpected);
+		assertError('attr(data-x type(<length))', parser, parser._parseFunction.bind(parser), ParseError.ExpressionExpected);
+	});
+
 	test('test token prio', function () {
 		const parser = new Parser();
 		assertNode('!important', parser, parser._parsePrio.bind(parser));


### PR DESCRIPTION
Fixes #451

`attr()` is parsed through the generic function machinery, so the modern `attr( <name> <type>?, <fallback>? )` form reported false syntax errors. `attr(data-x type(<length>))` produced `) expected` and `at-rule or selector expected` because the `<length>` syntax tokens inside `type()` aren't valid value terms.

This teaches the parser the `type( <syntax> )` argument (`*`, `<type-name>` components joined with `|`, with optional `+`/`#` multipliers), scoped to inside `attr()` via a small depth counter so a user-defined `type()` function elsewhere (e.g. a Sass `@function type()`) is left alone.

Everything that already parsed keeps parsing the same way — legacy `attr(name)` / `attr(name unit)` / `attr(name, fallback)`, `raw-string`, `type(*)`, empty `attr()`, and Sass/Less variables. Malformed types such as `attr(x type())` or `attr(x type(<length))` still report an error.

Added parser tests in `parser.test.ts` covering the legacy forms, the modern `type()` forms, the non-attr `type()` guard, and the malformed cases.