### PR TITLE
Use modern rgb() syntax in color completions

### DIFF
--- a/src/languageFacts/colors.ts
+++ b/src/languageFacts/colors.ts
@@ -14,9 +14,9 @@ const hexColorRegExp = /(^#([0-9A-F]{3}){1,2}$)|(^#([0-9A-F]{4}){1,2}$)/i;
 export const colorFunctions = [
 	{
 		label: 'rgb',
-		func: 'rgb($red, $green, $blue)',
-		insertText: 'rgb(${1:red}, ${2:green}, ${3:blue})',
-		desc: l10n.t('Creates a Color from red, green, and blue values.')
+		func: 'rgb($red $green $blue / $alpha)',
+		insertText: 'rgb(${1:red} ${2:green} ${3:blue} / ${4:alpha})',
+		desc: l10n.t('Creates a Color from red, green, blue, and alpha values.')
 	},
 	{
 		label: 'rgba',

--- a/src/test/css/completion.test.ts
+++ b/src/test/css/completion.test.ts
@@ -470,7 +470,7 @@ suite('CSS - Completion', () => {
 		});
 		await testCompletionFor('.foo { background-color: r|', {
 			items: [
-				{ label: 'rgb', kind: CompletionItemKind.Function, resultText: '.foo { background-color: rgb(${1:red}, ${2:green}, ${3:blue})' },
+				{ label: 'rgb', detail: 'rgb($red $green $blue / $alpha)', documentation: 'Creates a Color from red, green, blue, and alpha values.', kind: CompletionItemKind.Function, resultText: '.foo { background-color: rgb(${1:red} ${2:green} ${3:blue} / ${4:alpha})' },
 				{ label: 'rgba', kind: CompletionItemKind.Function, resultText: '.foo { background-color: rgba(${1:red}, ${2:green}, ${3:blue}, ${4:alpha})' },
 				{ label: 'rgb relative', kind: CompletionItemKind.Function, resultText: '.foo { background-color: rgb(from ${1:color} ${2:r} ${3:g} ${4:b})' },
 				{ label: 'red', kind: CompletionItemKind.Color, resultText: '.foo { background-color: red' },


### PR DESCRIPTION
Fixes #413

The `rgb` completion still inserts the legacy comma-separated three-channel form, so it cannot express alpha without switching to the legacy `rgba` alias.

This updates the `rgb` proposal to the CSS Color 4 space-separated form with an optional-alpha slot (`rgb(R G B / A)`). The existing `rgba` proposal remains available for users who want the legacy syntax. The completion test now covers the displayed signature, documentation, and inserted snippet.

Tests:
- `npm run compile` (TypeScript + ESLint)
- all 29 compiled test files via Node's test runner: 710 passing