### PR TITLE
Ignore unknown properties in ICSS :import blocks

### DIFF
--- a/src/services/lint.ts
+++ b/src/services/lint.ts
@@ -388,9 +388,10 @@ export class LintVisitor implements nodes.IVisitor {
 		//	Unknown propery & When using a vendor-prefixed gradient, make sure to use them all.
 		/////////////////////////////////////////////////////////////
 
-		const isExportBlock = node.getSelectors().matches(":export");
+		const selectors = node.getSelectors();
+		const isICSSBlock = selectors.matches(':export') || (selectors.startsWith(':import(') && selectors.endsWith(')'));
 
-		if (!isExportBlock) {
+		if (!isICSSBlock) {
 			const propertiesBySuffix = new NodesByRootMap();
 			let containsUnknowns = false;
 

--- a/src/test/css/lint.test.ts
+++ b/src/test/css/lint.test.ts
@@ -121,6 +121,7 @@ suite('CSS - Lint', () => {
 		assertRuleSet('selector { box-shadow: none }'); // no error
 		assertRuleSet('selector { box-property: "rest is missing" }', Rules.UnknownProperty);
 		assertRuleSet(':export { prop: "some" }'); // no error for properties inside :export
+		assertRuleSet(':import("something.scss") { __customProperty: customProperty; }'); // no error for properties inside :import
 		assertRuleSet2('selector { foo: "some"; bar: 0px }', [], undefined, new LintConfigurationSettings({ validProperties: ['foo', 'bar'] }));
 		assertRuleSet2('selector { foo: "some"; }', [], undefined, new LintConfigurationSettings({ validProperties: ['foo', null] }));
 		assertRuleSet2('selector { bar: "some"; }', [Rules.UnknownProperty], undefined, new LintConfigurationSettings({ validProperties: ['foo'] }));


### PR DESCRIPTION
Fixes #401

## Summary

- Treat functional ICSS `:import(...)` blocks like existing `:export` blocks during property linting.
- Avoid false `Unknown property` and IE-hack diagnostics for ICSS import aliases.
- Keep the existing property checks for ordinary selectors.

## Testing

- `npm run compile` (TypeScript and ESLint)
- Targeted CSS lint suite: 15/15 passed
- Full test suite: 710/710 passed across 29 test files