### PR TITLE
Add place-items value completions

### DIFF
--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -344,7 +344,7 @@ export class CSSCompletion {
 					}
 				}
 			}
-			this.getValueEnumProposals(entry, existingNode, result);
+			this.getValueEnumProposals(this.getValueEnumEntry(entry, node), existingNode, result);
 			this.getCSSWideKeywordProposals(entry, existingNode, result);
 			this.getUnitProposals(entry, existingNode, result);
 		} else {
@@ -360,6 +360,21 @@ export class CSSCompletion {
 		this.getVariableProposals(existingNode, result);
 		this.getTermProposals(entry, existingNode, result);
 		return result;
+	}
+
+	private getValueEnumEntry(entry: IPropertyData, declaration: nodes.Declaration): IPropertyData {
+		if (entry.values || !entry.syntax || typeof declaration.colonPosition !== 'number') {
+			return entry;
+		}
+
+		const match = /^\s*<'([^']+)'>\s+<'([^']+)'>\?\s*$/.exec(entry.syntax);
+		if (!match) {
+			return entry;
+		}
+
+		const completedValue = this.textDocument.getText().substring(declaration.colonPosition + 1, this.offset - this.currentWord.length).trim();
+		const referencedProperty = this.cssDataManager.getProperty(completedValue ? match[2] : match[1]);
+		return referencedProperty || entry;
 	}
 
 	public getValueEnumProposals(entry: IPropertyData | IDescriptorData, existingNode: nodes.Node | null, result: CompletionList): CompletionList {

--- a/src/test/css/completion.test.ts
+++ b/src/test/css/completion.test.ts
@@ -381,6 +381,17 @@ suite('CSS - Completion', () => {
 				{ label: 'space-evenly', resultText: '#id { justify-content: space-evenly' }
 			]
 		});
+		await testCompletionFor('body { place-items: |', {
+			items: [
+				{ label: 'center', resultText: 'body { place-items: center' },
+				{ label: 'auto', notAvailable: true }
+			]
+		});
+		await testCompletionFor('body { place-items: center |', {
+			items: [
+				{ label: 'auto', resultText: 'body { place-items: center auto' }
+			]
+		});
 		await testCompletionFor('.foo { te:n| }', {
 			items: [
 				{ label: 'n', notAvailable: true }


### PR DESCRIPTION
Fixes #455.

## Summary

- resolve value completions for two-property shorthands whose syntax references the longhand properties
- use `align-items` values for the first `place-items` value and `justify-items` values for the optional second value
- avoid copying generated CSS data into a special case

## Testing

- `npm run compile`
- full test suite: 710 passed