### PR TITLE
[scss][less] Accept keyframe selectors in nested rule set declarations

### DIFF
--- a/src/parser/lessParser.ts
+++ b/src/parser/lessParser.ts
@@ -178,12 +178,8 @@ export class LESSParser extends cssParser.Parser {
 		}
 		const content = <nodes.BodyDeclaration>this.create(nodes.BodyDeclaration);
 
-		this._parseBody(content, this._parseDetachedRuleSetBody.bind(this));
+		this._parseBody(content, this._parseRuleSetDeclaration.bind(this));
 		return this.finish(content);
-	}
-
-	public _parseDetachedRuleSetBody(): nodes.Node | null {
-		return this._tryParseKeyframeSelector() || this._parseRuleSetDeclaration();
 	}
 
 	public _addLookupChildren(node: nodes.Node): boolean {
@@ -330,6 +326,7 @@ export class LESSParser extends cssParser.Parser {
 			|| this._tryParseMixinReference() // less mixin reference
 			|| this._parseFunction()
 			|| this._parseExtend() // less extend declaration
+			|| this._tryParseKeyframeSelector() // keyframe selector, e.g. `0%` in content included into a @keyframes rule
 			|| this._parseDeclaration(); // try css ruleset declaration as the last option
 	}
 

--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -261,6 +261,7 @@ export class SCSSParser extends cssParser.Parser {
 		}
 		return this._parseVariableDeclaration() // variable declaration
 			|| this._tryParseRuleset(true) // nested ruleset
+			|| this._tryParseKeyframeSelector() // keyframe selector, e.g. `0%` in content included into a @keyframes rule
 			|| this._parseDeclaration(); // try css ruleset declaration as last so in the error case, the ast will contain a declaration
 	}
 
@@ -705,14 +706,10 @@ export class SCSSParser extends cssParser.Parser {
 		}
 
 		if (this.peek(TokenType.CurlyL)) {
-			this._parseBody(node, this._parseMixinReferenceBodyStatement.bind(this));
+			this._parseBody(node, this._parseRuleSetDeclaration.bind(this));
 		}
 
 		return this.finish(node);
-	}
-
-	public _parseMixinReferenceBodyStatement(): nodes.Node | null {
-		return this._tryParseKeyframeSelector() || this._parseRuleSetDeclaration();
 	}
 
 	public _parseIfTest(): nodes.Node | null {

--- a/src/test/less/parser.test.ts
+++ b/src/test/less/parser.test.ts
@@ -86,6 +86,8 @@ suite('LESS - Parser', () => {
 		assertNode('#truth (@a) when (@a = true) { }', parser, parser._tryParseMixinDeclaration.bind(parser));
 		assertNode('.color (@color; @padding: 2;) { }', parser, parser._tryParseMixinDeclaration.bind(parser));
 		assertNode('.font-face(@source, @target) { @font-face { font-family: @source; src: local(\'@{target}\');} }', parser, parser._tryParseMixinDeclaration.bind(parser));
+		assertNode('.slide(@from, @to) { 0% { transform: translateX(@from); } 100% { transform: translateX(@to); } }', parser, parser._tryParseMixinDeclaration.bind(parser)); // microsoft/vscode#227452
+		assertNode('.fade() { from, 50% { opacity: 0; } 75%, to { opacity: 1; } }', parser, parser._tryParseMixinDeclaration.bind(parser));
 		assertError('.color (@color; @padding: 2;;) { }', parser, parser._tryParseMixinDeclaration.bind(parser), ParseError.IdentifierExpected);
 		assertNode('.mixin-definition(@a: {}; @b: {default: works;};) { @a(); @b(); }', parser, parser._tryParseMixinDeclaration.bind(parser));
 	});

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -486,6 +486,9 @@ suite('SCSS - Parser', () => {
 		assertNode('@mixin #{foo}($color){}', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@mixin foo ($i:4) { size: $i; @include wee ($i - 1); }', parser, parser._parseStylesheet.bind(parser));
 		assertNode('@mixin foo ($i,) { }', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@mixin slideX($from, $to) { 0% { transform: translateX($from); } 100% { transform: translateX($to); } }', parser, parser._parseStylesheet.bind(parser)); // microsoft/vscode#227452
+		assertNode('@mixin fade { from, 50% { opacity: 0; } 75%, to { opacity: 1; } }', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@mixin fade($x) { @if $x { 0% { opacity: 0; } } @else { 100% { opacity: 1; } } }', parser, parser._parseStylesheet.bind(parser));
 
 		assertError('@mixin $1 {}', parser, parser._parseStylesheet.bind(parser), ParseError.IdentifierExpected);
 		assertError('@mixin foo() i {}', parser, parser._parseStylesheet.bind(parser), ParseError.LeftCurlyExpected);


### PR DESCRIPTION
Fixes microsoft/vscode#227452

## Problem

The SCSS parser reports false errors (`css-rcurlyexpected`, `css-ruleorselectorexpected`) for mixins that contain keyframe selectors, even though this is valid Sass that compiles fine:

```scss
@mixin slideX($from, $to) {
  0% { transform: translateX($from); }
  100% { transform: translateX($to); }
}

@keyframes slide-left { @include slideX(0, -100%); }
```

The same class of bug also reproduces one nesting level deeper (`@mixin a { @if $b { 0% { } } }`), inside `@include` content blocks wrapped in control statements, and in LESS parametric mixins (`.m() { 0% { } }` — cf. Microsoft/vscode#28091, which fixed only detached rulesets in 2017).

## Fix

Rather than adding another per-construct special case (there were already two: `_parseMixinReferenceBodyStatement` for scss `@include` bodies and `_parseDetachedRuleSetBody` for less detached rulesets, both added for vscode#28091), accept keyframe selectors in the shared nested fallback: the non-at-keyword branch of the scss/less `_parseRuleSetDeclaration` now tries `_tryParseKeyframeSelector`:

- **after** `_tryParseRuleset`, so plain nested rulesets like `e1 { }` keep their `RuleSet` node type (the existing `SCSS - Selector Printing › nested selector` test guards this), and
- **before** `_parseDeclaration`, which would otherwise consume `from, 50%` and emit a colon-expected error.

Because every nested construct (`@mixin` bodies, `@include` content blocks, `@if`/`@each`/`@for` bodies, less mixins and detached rulesets) funnels through `_parseRuleSetDeclaration`, this one change covers them all, and the two existing special-case body parsers are removed (net −9 lines in the parsers). `_tryParseKeyframeSelector` fully backtracks, so declarations, variable declarations and error recovery are unaffected.

Plain CSS is unchanged: `.a { 0% { } }` in a `.css` file still errors, since the base parser's `_parseRuleSetDeclaration` is untouched.

This matches dart-sass/less semantics, which parse rule bodies permissively and validate selectors at evaluation time (a mixin declaration cannot know its inclusion site).

## Tests

Added parser tests for scss (`0%`/`100%` in `@mixin`, mixed `from, 50%` lists, keyframe selectors under `@if`/`@else` inside a mixin) and less (parametric mixins with `0%`/`100%` and mixed lists). Full suite passes: 710 pass, 0 fail.