### PR TITLE
No completions inside comments

### DIFF
--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -68,21 +68,50 @@ export class CSSCompletion {
 	}
 
 	/**
+	 * A node never starts inside a comment, so the last node starting before `offset` is a safe
+	 * place to start scanning from: a comment holding `offset` cannot have started any earlier.
+	 */
+	private getCommentScanStart(styleSheet: nodes.Stylesheet, offset: number): number {
+		let node: nodes.Node | null = styleSheet;
+		let start = 0;
+		while (node) {
+			let last: nodes.Node | null = null;
+			for (const child of node.getChildren()) {
+				if (child.offset >= 0 && child.offset < offset) {
+					last = child; // children are in document order, so the last match wins
+				}
+			}
+			if (last) {
+				start = last.offset;
+				// `url(...)` is scanned in a dedicated mode, so never start inside one.
+				const uriLiteral = last.findParent(nodes.NodeType.URILiteral);
+				if (uriLiteral) {
+					return uriLiteral.offset;
+				}
+			}
+			node = last;
+		}
+		return start;
+	}
+
+	/**
 	 * Comments are not part of the node tree, so they have to be located by scanning the document.
 	 */
-	private isInComment(document: TextDocument, offset: number): boolean {
+	private isInComment(document: TextDocument, styleSheet: nodes.Stylesheet, offset: number): boolean {
 		const scanner = this.getScanner();
 		scanner.ignoreComment = false;
 		scanner.setSource(document.getText());
+		scanner.goBackTo(this.getCommentScanStart(styleSheet, offset));
 
 		let previous: IToken | undefined;
 		for (let token = scanner.scan(); token.type !== TokenType.EOF && token.offset <= offset; token = scanner.scan()) {
-			// `//` does not start a comment inside an unquoted URL, so keep the scanner in the same
-			// state the parser puts it in when it enters `url(...)`.
+			// `//` does not start a comment inside an unquoted URL. `_parseURILiteral` reads the whole
+			// argument as one unquoted string with URL mode on and turns it off right after, so do the
+			// same rather than leaving the scanner in URL mode until some later token.
 			if (token.type === TokenType.ParenthesisL && previous && previous.type === TokenType.Ident
 				&& previous.offset + previous.len === token.offset && /^url(-prefix)?$/i.test(previous.text)) {
 				scanner.inURL = true;
-			} else if (token.type === TokenType.ParenthesisR) {
+				scanner.scanUnquotedString(); // null for a quoted or empty argument, which scans normally
 				scanner.inURL = false;
 			}
 			previous = token;
@@ -94,8 +123,10 @@ export class CSSCompletion {
 			if (offset < end) {
 				return true;
 			}
-			// At the end of a comment that was never closed (`/* ...` or `// ...`) the text still belongs to the comment.
-			if (offset === end && !token.text.endsWith('*/')) {
+			// At the end of a comment that was never closed (`/* ...` or `// ...`) the text still belongs
+			// to the comment. Only a block comment can be closed, and `/*/` is not one despite its end.
+			const isClosed = token.text.startsWith('/*') && token.len >= 4 && token.text.endsWith('*/');
+			if (offset === end && !isClosed) {
 				return true;
 			}
 		}
@@ -138,7 +169,7 @@ export class CSSCompletion {
 
 	public doComplete(document: TextDocument, position: Position, styleSheet: nodes.Stylesheet, documentSettings: CompletionSettings | undefined): CompletionList {
 		this.offset = document.offsetAt(position);
-		if (this.isInComment(document, this.offset)) {
+		if (this.isInComment(document, styleSheet, this.offset)) {
 			return { isIncomplete: false, items: [] };
 		}
 		this.position = position;

--- a/src/services/cssCompletion.ts
+++ b/src/services/cssCompletion.ts
@@ -18,6 +18,7 @@ import * as l10n from '@vscode/l10n';
 import { isDefined } from '../utils/objects.js';
 import { CSSDataManager } from '../languageFacts/dataManager.js';
 import { PathCompletionParticipant } from './pathCompletion.js';
+import { IToken, Scanner, TokenType } from '../parser/cssScanner.js';
 
 const SnippetFormat = InsertTextFormat.Snippet;
 
@@ -62,6 +63,45 @@ export class CSSCompletion {
 		this.defaultSettings = settings;
 	}
 
+	protected getScanner(): Scanner {
+		return new Scanner();
+	}
+
+	/**
+	 * Comments are not part of the node tree, so they have to be located by scanning the document.
+	 */
+	private isInComment(document: TextDocument, offset: number): boolean {
+		const scanner = this.getScanner();
+		scanner.ignoreComment = false;
+		scanner.setSource(document.getText());
+
+		let previous: IToken | undefined;
+		for (let token = scanner.scan(); token.type !== TokenType.EOF && token.offset <= offset; token = scanner.scan()) {
+			// `//` does not start a comment inside an unquoted URL, so keep the scanner in the same
+			// state the parser puts it in when it enters `url(...)`.
+			if (token.type === TokenType.ParenthesisL && previous && previous.type === TokenType.Ident
+				&& previous.offset + previous.len === token.offset && /^url(-prefix)?$/i.test(previous.text)) {
+				scanner.inURL = true;
+			} else if (token.type === TokenType.ParenthesisR) {
+				scanner.inURL = false;
+			}
+			previous = token;
+
+			if (token.type !== TokenType.Comment || offset <= token.offset) {
+				continue;
+			}
+			const end = token.offset + token.len;
+			if (offset < end) {
+				return true;
+			}
+			// At the end of a comment that was never closed (`/* ...` or `// ...`) the text still belongs to the comment.
+			if (offset === end && !token.text.endsWith('*/')) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	protected getSymbolContext(): Symbols {
 		if (!this.symbolContext) {
 			this.symbolContext = new Symbols(this.styleSheet);
@@ -98,6 +138,9 @@ export class CSSCompletion {
 
 	public doComplete(document: TextDocument, position: Position, styleSheet: nodes.Stylesheet, documentSettings: CompletionSettings | undefined): CompletionList {
 		this.offset = document.offsetAt(position);
+		if (this.isInComment(document, this.offset)) {
+			return { isIncomplete: false, items: [] };
+		}
 		this.position = position;
 		this.currentWord = getCurrentWord(document, this.offset);
 		this.defaultReplaceRange = Range.create(Position.create(this.position.line, this.position.character - this.currentWord.length), this.position);

--- a/src/services/lessCompletion.ts
+++ b/src/services/lessCompletion.ts
@@ -10,6 +10,8 @@ import { CompletionList, CompletionItemKind, InsertTextFormat, TextEdit, Complet
 
 import * as l10n from '@vscode/l10n';
 import { CSSDataManager } from '../languageFacts/dataManager.js';
+import { Scanner } from '../parser/cssScanner.js';
+import { LESSScanner } from '../parser/lessScanner.js';
 
 interface IFunctionInfo {
 	name: string;
@@ -358,6 +360,10 @@ export class LESSCompletion extends CSSCompletion {
 
 	constructor(lsOptions: LanguageServiceOptions, cssDataManager: CSSDataManager) {
 		super('@', lsOptions, cssDataManager);
+	}
+
+	protected getScanner(): Scanner {
+		return new LESSScanner();
 	}
 
 	private createFunctionProposals(proposals: IFunctionInfo[], existingNode: nodes.Node, sortToEnd: boolean, result: CompletionList): CompletionList {

--- a/src/services/scssCompletion.ts
+++ b/src/services/scssCompletion.ts
@@ -9,6 +9,8 @@ import * as nodes from '../parser/cssNodes.js';
 import { CompletionList, CompletionItemKind, TextEdit, InsertTextFormat, CompletionItem, MarkupContent, IReference, LanguageServiceOptions, IPropertyData } from '../cssLanguageTypes.js';
 import * as l10n from '@vscode/l10n';
 import { CSSDataManager } from '../languageFacts/dataManager.js';
+import { Scanner } from '../parser/cssScanner.js';
+import { SCSSScanner } from '../parser/scssScanner.js';
 
 interface IFunctionInfo {
 	func: string;
@@ -261,6 +263,10 @@ export class SCSSCompletion extends CSSCompletion {
 
 		addReferencesToDocumentation(SCSSCompletion.scssModuleLoaders);
 		addReferencesToDocumentation(SCSSCompletion.scssModuleBuiltIns);
+	}
+
+	protected getScanner(): Scanner {
+		return new SCSSScanner();
 	}
 
 	protected isImportPathParent(type: nodes.NodeType): boolean {

--- a/src/test/css/completion.test.ts
+++ b/src/test/css/completion.test.ts
@@ -995,6 +995,7 @@ suite('CSS - Completion', () => {
 		await testCompletionFor('.foo { color: /* re| */ red }', { count: 0 });
 		await testCompletionFor('/* multi\n * line foo:|\n */', { count: 0 });
 		await testCompletionFor('/* never closed foo:|', { count: 0 });
+		await testCompletionFor('/*/|', { count: 0 }); // `/*/` ends with `*/` but is not closed
 		await testCompletionFor('.foo { }\n/* @med| */', { count: 0 });
 	});
 

--- a/src/test/css/completion.test.ts
+++ b/src/test/css/completion.test.ts
@@ -141,7 +141,7 @@ export async function testCompletionFor(
 	}
 
 	const document = TextDocument.create(testUri, lang, 0, value);
-	const position = Position.create(0, offset);
+	const position = document.positionAt(offset);
 	const jsonDoc = ls.parseStylesheet(document);
 
 	const context = getDocumentContext(workspaceFolderUri);
@@ -988,6 +988,22 @@ suite('CSS - Completion', () => {
 			]
 		});
 	})
+
+	test('no completions in comments', async function () {
+		await testCompletionFor('/* foo:| */', { count: 0 });
+		await testCompletionFor('.foo { /* colo| */ }', { count: 0 });
+		await testCompletionFor('.foo { color: /* re| */ red }', { count: 0 });
+		await testCompletionFor('/* multi\n * line foo:|\n */', { count: 0 });
+		await testCompletionFor('/* never closed foo:|', { count: 0 });
+		await testCompletionFor('.foo { }\n/* @med| */', { count: 0 });
+	});
+
+	test('completions next to comments', async function () {
+		await testCompletionFor('|/* foo */', { items: [{ label: '@media' }] });
+		await testCompletionFor('/* foo */ a:|', { items: [{ label: ':hover' }] });
+		await testCompletionFor('.foo { /* c */ colo| }', { items: [{ label: 'color' }] });
+		await testCompletionFor('.foo { color: red /* c */; }\n.bar { colo| }', { items: [{ label: 'color' }] });
+	});
 
 	test('@media at rule completion', async function () {
 		await testCompletionFor(`@media (|) {`, {

--- a/src/test/less/lessCompletion.test.ts
+++ b/src/test/less/lessCompletion.test.ts
@@ -6,7 +6,7 @@
 
 import { suite, test } from 'node:test';
 import { testCompletionFor as testCSSCompletionFor, ExpectedCompetions } from '../css/completion.test.js';
-import { LanguageSettings } from '../../cssLanguageService.js';
+import { LanguageSettings, Position } from '../../cssLanguageService.js';
 import { newRange } from '../css/navigation.test.js';
 
 function testCompletionFor(
@@ -109,12 +109,20 @@ suite('LESS - Completions', () => {
 		await testCompletionFor('// foo:|', { count: 0 });
 		await testCompletionFor('.foo { // colo|\n}', { count: 0 });
 		await testCompletionFor('.foo { /* colo| */ }', { count: 0 });
+		// an unterminated `url(` must not leave the scanner in URL mode for the rest of the document
+		await testCompletionFor('.foo { background: url(\n}\n// colo|', { count: 0 });
 	});
 
 	test('completions next to comments', async () => {
 		await testCompletionFor('// foo\n.foo { colo| }', { items: [{ label: 'color' }] });
 		// `//` inside an unquoted URL does not start a comment
 		await testCompletionFor('.foo { background: url(http://server/a.png); colo| }', { items: [{ label: 'color' }] });
+		// the same holds with the cursor inside the URL, where the scan has to start before `url(`
+		await testCompletionFor('.a { background: url(http://ex.com/a|) }', {
+			participant: {
+				onURILiteralValue: [{ uriValue: 'http://ex.com/a', position: Position.create(0, 36), range: newRange(21, 36) }]
+			}
+		});
 	});
 
 	test('suggestParticipants', async () => {

--- a/src/test/less/lessCompletion.test.ts
+++ b/src/test/less/lessCompletion.test.ts
@@ -105,6 +105,18 @@ suite('LESS - Completions', () => {
 		});
 	});
 
+	test('no completions in comments', async () => {
+		await testCompletionFor('// foo:|', { count: 0 });
+		await testCompletionFor('.foo { // colo|\n}', { count: 0 });
+		await testCompletionFor('.foo { /* colo| */ }', { count: 0 });
+	});
+
+	test('completions next to comments', async () => {
+		await testCompletionFor('// foo\n.foo { colo| }', { items: [{ label: 'color' }] });
+		// `//` inside an unquoted URL does not start a comment
+		await testCompletionFor('.foo { background: url(http://server/a.png); colo| }', { items: [{ label: 'color' }] });
+	});
+
 	test('suggestParticipants', async () => {
 		await testCompletionFor(`html { .m| }`, {
 			participant: {

--- a/src/test/scss/scssCompletion.test.ts
+++ b/src/test/scss/scssCompletion.test.ts
@@ -309,4 +309,20 @@ suite('SCSS - Completions', () => {
 		}, undefined, testSCSSUri, workspaceFolderUri);
 	});
 
+	test('no completions in comments', async () => {
+		await testCompletionFor('// foo:|', { count: 0 });
+		await testCompletionFor('.foo { // colo|\n}', { count: 0 });
+		await testCompletionFor('.foo { /* colo| */ }', { count: 0 });
+		await testCompletionFor('@mixin foo { // $var|\n}', { count: 0 });
+	});
+
+	test('completions next to comments', async () => {
+		await testCompletionFor('// foo\n.foo { colo| }', { items: [{ label: 'color' }] });
+		// `//` inside an unquoted URL does not start a comment
+		await testCompletionFor('.foo { background: url(http://server/a.png); colo| }', { items: [{ label: 'color' }] });
+		await testCompletionFor('.foo { background: url(//server/a.png); colo| }', { items: [{ label: 'color' }] });
+		// nor does it inside a string
+		await testCompletionFor('.foo { content: "http://server"; colo| }', { items: [{ label: 'color' }] });
+	});
+
 });

--- a/src/test/scss/scssCompletion.test.ts
+++ b/src/test/scss/scssCompletion.test.ts
@@ -313,6 +313,8 @@ suite('SCSS - Completions', () => {
 		await testCompletionFor('// foo:|', { count: 0 });
 		await testCompletionFor('.foo { // colo|\n}', { count: 0 });
 		await testCompletionFor('.foo { /* colo| */ }', { count: 0 });
+		// an unterminated `url(` must not leave the scanner in URL mode for the rest of the document
+		await testCompletionFor('.foo { background: url(\n}\n// colo|', { count: 0 });
 		await testCompletionFor('@mixin foo { // $var|\n}', { count: 0 });
 	});
 
@@ -320,6 +322,12 @@ suite('SCSS - Completions', () => {
 		await testCompletionFor('// foo\n.foo { colo| }', { items: [{ label: 'color' }] });
 		// `//` inside an unquoted URL does not start a comment
 		await testCompletionFor('.foo { background: url(http://server/a.png); colo| }', { items: [{ label: 'color' }] });
+		// the same holds with the cursor inside the URL, where the scan has to start before `url(`
+		await testCompletionFor('.a { background: url(http://ex.com/a|) }', {
+			participant: {
+				onURILiteralValue: [{ uriValue: 'http://ex.com/a', position: Position.create(0, 36), range: newRange(21, 36) }]
+			}
+		});
 		await testCompletionFor('.foo { background: url(//server/a.png); colo| }', { items: [{ label: 'color' }] });
 		// nor does it inside a string
 		await testCompletionFor('.foo { content: "http://server"; colo| }', { items: [{ label: 'color' }] });


### PR DESCRIPTION
Fixes #429

### Problem

Comments are trivia and never make it into the node tree, so `doComplete` resolves the node path as if the comment were not there. Typing inside a comment therefore offers the completions of the *surrounding* context:

```css
/* foo: */            ← at-rules and selectors
.foo { /* color: */ } ← the full property list
```

The symptom reported in #429 is the most visible one: typing a `:` anywhere in a comment pops up the entire pseudo-class/pseudo-element list. It applies to SCSS/LESS `// ...` line comments as well.

### Fix

Locate comments by scanning the document (`Scanner` with `ignoreComment = false`) and return an empty list when the position is inside one. `SCSSCompletion`/`LESSCompletion` override `getScanner` so `//` line comments are recognized in those dialects.

Two details worth calling out:

- The scan mirrors the parser's `inURL` handling. Without it, `//` in an unquoted `url(http://server/a.png)` scans as a line comment in SCSS/LESS and would have suppressed completions for the rest of the line. There are tests for both the unquoted and the protocol-relative (`url(//server/a.png)`) form.
- A position at the very end of a comment that was never closed (`/* ...` at EOF, or `// ...` at EOL) still counts as inside it, while a position right after a closing `*/` does not.

The scan stops as soon as it passes the requested offset, so it does not walk the whole document.

### Tests

Added `no completions in comments` / `completions next to comments` to the CSS, SCSS and LESS completion tests.

One test-infra change was needed: `testCompletionFor` built its position with `Position.create(0, offset)`, which silently clamps to the first line and made multi-line test inputs untestable. It now uses `document.positionAt(offset)` — identical for single-line inputs, which is every existing case.

All 722 tests pass.