### PR TITLE
[scss] Support bracketed lists

### DIFF
--- a/src/parser/scssParser.ts
+++ b/src/parser/scssParser.ts
@@ -198,6 +198,22 @@ export class SCSSParser extends cssParser.Parser {
 			super._parseTermExpression();
 	}
 
+	public _parseNamedLine(): nodes.Node | null {
+		// Sass bracketed lists are a superset of the CSS named-line syntax: the brackets may hold any
+		// space or comma separated list of values, not just a sequence of identifiers.
+		// https://sass-lang.com/documentation/values/lists/#bracketed-lists
+		if (!this.peek(TokenType.BracketL)) {
+			return null;
+		}
+		const node = this.createNode(nodes.NodeType.GridLine);
+		this.consumeToken();
+		node.addChild(this._parseExpr()); // the list may be empty
+		if (!this.accept(TokenType.BracketR)) {
+			return this.finish(node, ParseError.RightSquareBracketExpected);
+		}
+		return this.finish(node);
+	}
+
 	public _parseInterpolation(): nodes.Node | null {
 		if (this.peek(scssScanner.InterpolationFunction)) {
 			const node = this.create(nodes.Interpolation);

--- a/src/test/scss/parser.test.ts
+++ b/src/test/scss/parser.test.ts
@@ -51,6 +51,8 @@ suite('SCSS - Parser', () => {
 		assertNode('$footer-height: 40px !default !global', parser, parser._parseVariableDeclaration.bind(parser));
 		assertNode('$primary-font: "wf_SegoeUI","Segoe UI","Segoe","Segoe WP"', parser, parser._parseVariableDeclaration.bind(parser));
 		assertNode('$color: red !important', parser, parser._parseVariableDeclaration.bind(parser));
+		assertNode('$colors: ["#69ffae", "#1ae5b5"]', parser, parser._parseVariableDeclaration.bind(parser)); // #399
+		assertNode('$sizes: [1px, 2px] !default', parser, parser._parseVariableDeclaration.bind(parser)); // #231
 
 		assertError('$color: red !def', parser, parser._parseVariableDeclaration.bind(parser), ParseError.UnknownKeyword);
 		assertError('$color : !default', parser, parser._parseVariableDeclaration.bind(parser), ParseError.VariableValueExpected);
@@ -131,6 +133,35 @@ suite('SCSS - Parser', () => {
 		assertNode('not module.$v', parser, parser._parseExpr.bind(parser));
 
 		assertError('(20 + 20', parser, parser._parseExpr.bind(parser), ParseError.RightParenthesisExpected);
+	});
+
+	test('Bracketed list in a stylesheet', function () {
+		const parser = new SCSSParser();
+		assertNode('.a { $x: [1px, 2px]; }', parser, parser._parseStylesheet.bind(parser)); // #231
+		assertNode('@use "sass:list"; .a { color: list.nth([a, b], 2); }', parser, parser._parseStylesheet.bind(parser)); // #399
+		assertNode('$m: (k: [a, b], j: [c]);', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@mixin m($x: [a, b]) { color: red; }', parser, parser._parseStylesheet.bind(parser));
+		assertNode('@each $i in [a, b] { .#{$i} { color: red; } }', parser, parser._parseStylesheet.bind(parser));
+	});
+
+	test('Bracketed list', function () {
+		const parser = new SCSSParser();
+		// https://sass-lang.com/documentation/values/lists/#bracketed-lists
+		assertNode('[]', parser, parser._parseExpr.bind(parser));
+		assertNode('[a]', parser, parser._parseExpr.bind(parser));
+		assertNode('[a b c]', parser, parser._parseExpr.bind(parser));
+		assertNode('[a, b, c]', parser, parser._parseExpr.bind(parser));
+		assertNode('[a, b,]', parser, parser._parseExpr.bind(parser));
+		assertNode('[1px, 2em, 3%]', parser, parser._parseExpr.bind(parser));
+		assertNode('[$a, $b]', parser, parser._parseExpr.bind(parser));
+		assertNode('[#{$a}, b]', parser, parser._parseExpr.bind(parser));
+		assertNode('[[a, b], [c d]]', parser, parser._parseExpr.bind(parser));
+		assertNode('[math.div(6, 2), 2]', parser, parser._parseExpr.bind(parser));
+
+		// the CSS named-line syntax keeps working
+		assertNode('[full-start] 1fr [full-end]', parser, parser._parseExpr.bind(parser));
+
+		assertError('[a, b', parser, parser._parseExpr.bind(parser), ParseError.RightSquareBracketExpected);
 	});
 
 	test('SCSSOperator', function () {


### PR DESCRIPTION
Fixes #231
Fixes #399

## Problem

Sass [bracketed lists](https://sass-lang.com/documentation/values/lists/#bracketed-lists) are reported as syntax errors:

```scss
.a { $x: [1px, 2px]; }
//        ^ ] expected
//               ^ semi-colon expected
//                 ^ at-rule or selector expected
```

The only production that accepts `[` in a value position is `_parseNamedLine`, which implements the CSS [named-line](https://www.w3.org/TR/css-grid-1/#named-lines) syntax and therefore only accepts a bare sequence of identifiers. That happens to cover `[a b c]`, so space-separated lists of idents already worked — but anything else (commas, numbers, strings, variables, interpolation, function calls, nesting) fell through and produced a cascade of errors.

## Fix

Override `_parseNamedLine` in `SCSSParser` so the brackets hold a full expression. A Sass bracketed list is a superset of the CSS named-line syntax, so the one production covers both; CSS and LESS are untouched.

## Now parsing cleanly

```scss
$x: [];                            // empty
$x: [a];
$x: [a, b, c];                     // comma separated
$x: [a, b,];                       // trailing comma
$x: [1px, 2em, 3%];
$x: [$a, $b];
$x: [#{$a}, b];                    // interpolation
$x: [[a, b], [c d]];               // nested
$x: [math.div(6, 2), 2];           // function call
$m: (k: [a, b], j: [c]);           // as a map value
@mixin m($x: [a, b]) { }           // as a default parameter
@each $i in [a, b] { }
.a { color: list.nth([a, b], 2); } // as an argument
```

Still reported as errors:

```scss
$x: [a, b;   // ] expected
$x: a];      // semi-colon expected
```

And the CSS named-line syntax keeps working in both CSS and SCSS:

```scss
.a { grid-template-columns: [full-start] 1fr [full-end]; }
.a { grid-template-rows: [r1-start r2] 25% [r2-end]; }
```

## Testing

`npm run test` — 712 passing, 0 failing (710 before, plus the new cases).

New tests in `src/test/scss/parser.test.ts`: a `Bracketed list` block covering the forms above plus the `RightSquareBracketExpected` error case, a `Bracketed list in a stylesheet` block covering the end-to-end usages from both issues, and two cases added to `VariableDeclaration`.
